### PR TITLE
Add parser for the output of data_d_array

### DIFF
--- a/pytao/interface_commands.py
+++ b/pytao/interface_commands.py
@@ -755,7 +755,13 @@ def data_d_array(tao, d2_name, d1_name, *, ix_universe='', verbose=False, as_dic
     
     Returns
     -------
-    string_list
+    datums: list of dicts
+        Each dict has keys:
+        'ix_d1', 'data_type', 'merit_type', 
+        'ele_ref_name', 'ele_start_name', 'ele_name', 
+        'meas_value', 'model_value', 'design_value', 
+        'useit_opt', 'useit_plot', 'good_user', 
+        'weight', 'exists'
     
     Notes
     -----

--- a/pytao/util/parsers.py
+++ b/pytao/util/parsers.py
@@ -3,7 +3,9 @@ import numpy as np
 
 
 
-data_d_cols =  ['ix_d1',
+
+# Column names and types for parse_data_d_array
+DATA_D_COLS =  ['ix_d1',
  'data_type',
  'merit_type',
  'ele_ref_name',
@@ -17,7 +19,7 @@ data_d_cols =  ['ix_d1',
  'good_user',
  'weight',
  'exists']
-data_d_types = [int, str, str, str, str, str, float, float, float, bool, bool, bool, float, bool]
+DATA_D_TYPES = [int, str, str, str, str, str, float, float, float, bool, bool, bool, float, bool]
 
 def parse_data_d_array(lines):
     """
@@ -53,7 +55,7 @@ def parse_data_d_array(lines):
         d = {}
         result.append(d)
         vals = line.split(';')
-        for name, typ, val in zip(data_d_cols, data_d_types, vals):
+        for name, typ, val in zip(DATA_D_COLS, DATA_D_TYPES, vals):
             d[name] = typ(val)
         
     return result

--- a/pytao/util/parsers.py
+++ b/pytao/util/parsers.py
@@ -1,6 +1,65 @@
 import numpy as np
 
 
+
+
+data_d_cols =  ['ix_d1',
+ 'data_type',
+ 'merit_type',
+ 'ele_ref_name',
+ 'ele_start_name',
+ 'ele_name',
+ 'meas_value',
+ 'model_value',
+ 'design_value',
+ 'useit_opt',
+ 'useit_plot',
+ 'good_user',
+ 'weight',
+ 'exists']
+data_d_types = [int, str, str, str, str, str, float, float, float, bool, bool, bool, float, bool]
+
+def parse_data_d_array(lines):
+    """
+    Parses the output of the 'python data_d_array' command into a list of dicts. 
+    
+    This can be easily be case into a table. For example:
+    
+    import pandas as pd
+    ...
+    lines = tao.data_d_array('orbit', 'x')
+    dat = parse_data_d_array(lines)
+    df = pd.DataFrame(dat)
+    
+    
+    Parameters
+    ----------
+    lines : list of str
+        The output of the 'python data_d_array' command to parse
+    
+    Returns
+    -------
+    datums: list of dicts
+            Each dict has keys:
+            'ix_d1', 'data_type', 'merit_type', 
+            'ele_ref_name', 'ele_start_name', 'ele_name', 
+            'meas_value', 'model_value', 'design_value', 
+            'useit_opt', 'useit_plot', 'good_user', 
+            'weight', 'exists'
+    
+    """ 
+    result = []
+    for line in lines:
+        d = {}
+        result.append(d)
+        vals = line.split(';')
+        for name, typ, val in zip(data_d_cols, data_d_types, vals):
+            d[name] = typ(val)
+        
+    return result
+
+
+
 def parse_derivative(lines):
     """
     Parses the output of tao python derivative


### PR DESCRIPTION
This parses the string output of data_d_array so that:
`tao.data_d_array('orbit', 'x')`

returns a list of dicts, like:
```python

[{'ix_d1': 1,
  'data_type': 'bpm_orbit.x',
  'merit_type': 'target',
  'ele_ref_name': '',
  'ele_start_name': '',
  'ele_name': 'BPM10',
  'meas_value': 0.0,
  'model_value': 1.19045903284358e-08,
  'design_value': 1.19045903284358e-08,
  'useit_opt': True,
  'useit_plot': True,
  'good_user': True,
  'weight': 1.0,
  'exists': True},
... ]
```
