### PR TITLE
BLD: mkdocs-jupyter from pip for now

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -21,9 +21,12 @@ dependencies:
   - mkdocs
   - mkdocstrings
   - mkdocs-material
-  - mkdocs-jupyter
+  # NOTE: we are installing mkdocs-jupyter with pip for now
+  # due to the following: https://github.com/conda-forge/mkdocs-jupyter-feedstock/issues/31
+  # - mkdocs-jupyter
   - mkdocstrings-python
   - pip
   - pip:
+      - mkdocs-jupyter>=0.24.7
       # Install pytao from here.
       - .


### PR DESCRIPTION
## Description

Install mkdocs-jupyter with pip for now due to the following: https://github.com/conda-forge/mkdocs-jupyter-feedstock/issues/31

## Context
Failure seen in https://github.com/bmad-sim/pytao/actions/runs/9667926944