### PR TITLE
Improved Error Reporting on Library Load

### DIFF
--- a/pytao/tao_ctypes/core.py
+++ b/pytao/tao_ctypes/core.py
@@ -62,12 +62,12 @@ class TaoCore:
         # Library was found from ACC_ROOT_DIR environment variable
         if self.so_lib_file:
             self.so_lib = ctypes.CDLL(self.so_lib_file)
-        
+
         # Try loading from system path
         else:
             # Find shared library from path and load it (finds regardless of extensions like .so or .dylib)
             self.so_lib, self.so_lib_file = auto_discovery_libtao()
-            
+
             # Raise an error if not found
             if self.so_lib_file is None:
                 raise ValueError("Shared object libtao library not found.")
@@ -314,7 +314,7 @@ def auto_discovery_libtao():
     Use system loader to try and find libtao.
     """
     # Find tao library regardless of suffix (ie .so, .dylib, etc) and load
-    so_lib_file = find_library('tao')
+    so_lib_file = find_library("tao")
     so_lib = ctypes.CDLL(so_lib_file) if so_lib_file is not None else None
     return so_lib, so_lib_file
 

--- a/pytao/tao_ctypes/core.py
+++ b/pytao/tao_ctypes/core.py
@@ -58,16 +58,17 @@ class TaoCore:
         else:
             self.so_lib_file = so_lib
 
+        # Library was found from ACC_ROOT_DIR environment variable
         if self.so_lib_file:
             self.so_lib = ctypes.CDLL(self.so_lib_file)
+        
+        # Try loading from system path
         else:
-            # Find shared library from path and load it
-            lib, lib_file = auto_discovery_libtao()
-
-            if lib:
-                self.so_lib = lib
-                self.so_lib_file = lib_file
-            else:
+            # Find shared library from path and load it (finds regardless of extensions like .so or .dylib)
+            self.so_lib, self.so_lib_file = auto_discovery_libtao()
+            
+            # Raise an error if not found
+            if self.so_lib_file is None:
                 raise ValueError("Shared object libtao library not found.")
 
         self.so_lib.tao_c_out_io_buffer_get_line.restype = ctypes.c_char_p
@@ -311,16 +312,9 @@ def auto_discovery_libtao():
     """
     Use system loader to try and find libtao.
     """
-    # Find tao library regardless of suffix (ie .so, .dylib, etc)
+    # Find tao library regardless of suffix (ie .so, .dylib, etc) and load
     lib = ctypes.util.find_library('tao')
-    
-    # Try to load it
-    if lib is not None:
-        lib_handler = ctypes.CDLL(lib)
-    else:
-        lib_handler = None
-
-    # Return handler and library name
+    lib_handler = ctypes.CDLL(lib) if lib is not None else None
     return lib_handler, lib
 
 

--- a/pytao/tao_ctypes/core.py
+++ b/pytao/tao_ctypes/core.py
@@ -313,9 +313,9 @@ def auto_discovery_libtao():
     Use system loader to try and find libtao.
     """
     # Find tao library regardless of suffix (ie .so, .dylib, etc) and load
-    lib = ctypes.util.find_library('tao')
-    lib_handler = ctypes.CDLL(lib) if lib is not None else None
-    return lib_handler, lib
+    so_lib_file = ctypes.util.find_library('tao')
+    so_lib = ctypes.CDLL(so_lib_file) if so_lib_file is not None else None
+    return so_lib, so_lib_file
 
 
 # ----------------------------------------------------------------------

--- a/pytao/tao_ctypes/core.py
+++ b/pytao/tao_ctypes/core.py
@@ -1,4 +1,5 @@
 import ctypes
+from ctypes.util import find_library
 import logging
 import os
 import shutil
@@ -313,7 +314,7 @@ def auto_discovery_libtao():
     Use system loader to try and find libtao.
     """
     # Find tao library regardless of suffix (ie .so, .dylib, etc) and load
-    so_lib_file = ctypes.util.find_library('tao')
+    so_lib_file = find_library('tao')
     so_lib = ctypes.CDLL(so_lib_file) if so_lib_file is not None else None
     return so_lib, so_lib_file
 

--- a/pytao/tao_ctypes/core.py
+++ b/pytao/tao_ctypes/core.py
@@ -61,6 +61,7 @@ class TaoCore:
         if self.so_lib_file:
             self.so_lib = ctypes.CDLL(self.so_lib_file)
         else:
+            # Find shared library from path and load it
             lib, lib_file = auto_discovery_libtao()
 
             if lib:
@@ -310,13 +311,17 @@ def auto_discovery_libtao():
     """
     Use system loader to try and find libtao.
     """
-    for lib in ["libtao.so", "libtao.dylib", "libtao.dll"]:
-        try:
-            lib_handler = ctypes.CDLL(lib)
-            return lib_handler, lib
-        except OSError:
-            continue
-    return None, None
+    # Find tao library regardless of suffix (ie .so, .dylib, etc)
+    lib = ctypes.util.find_library('tao')
+    
+    # Try to load it
+    if lib is not None:
+        lib_handler = ctypes.CDLL(lib)
+    else:
+        lib_handler = None
+
+    # Return handler and library name
+    return lib_handler, lib
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
This PR causes pytao to pass exceptions related to loading of the library unaltered to the user. This will help to make debugging of installation problems easier when they may be otherwise obscured by the `try... catch...` block.

Recently an issue related to loading `libtao.dylib` on mac was caused by missing symbols in another library. This was reported with the following error on creating a `Tao` object.
```
ValueError: Shared object libtao library not found.
```

Digging deeper into the loading issue, the library did exist, but caused this error on load.
```
Python 3.12.2 | packaged by conda-forge | (main, Feb 16 2024, 20:54:21) [Clang 16.0.6 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import ctypes
>>> ctypes.CDLL('libtao.dylib')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/chris/miniforge3/envs/myenv/lib/python3.12/ctypes/__init__.py", line 379, in __init__
    self._handle = _dlopen(self._name, mode)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: dlopen(libtao.dylib, 0x0006): symbol not found in flat namespace '_clagge_'
```

With this PR, the code which loads the library is changed to use the `ctypes` find_library function and then the loading itself is performed without a `try... catch...` block. After testing the code, I get the following when bmad is not installed.
```
Python 3.12.2 | packaged by conda-forge | (main, Feb 16 2024, 20:54:21) [Clang 16.0.6 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from pytao import Tao
>>> Tao()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/chris/pytao/pytao/tao_ctypes/core.py", line 73, in __init__
    raise ValueError("Shared object libtao library not found.")
ValueError: Shared object libtao library not found.
```

This is the output with the latest version of bmad (with a loading error)
```
Python 3.12.2 | packaged by conda-forge | (main, Feb 16 2024, 20:54:21) [Clang 16.0.6 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from pytao import Tao
>>> Tao()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/chris/pytao/pytao/tao_ctypes/core.py", line 69, in __init__
    self.so_lib, self.so_lib_file = auto_discovery_libtao()
                                    ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chris/pytao/pytao/tao_ctypes/core.py", line 318, in auto_discovery_libtao
    so_lib = ctypes.CDLL(so_lib_file) if so_lib_file is not None else None
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chris/miniforge3/envs/myenv/lib/python3.12/ctypes/__init__.py", line 379, in __init__
    self._handle = _dlopen(self._name, mode)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: dlopen(/Users/chris/miniforge3/envs/myenv/bin/../lib/libtao.dylib, 0x0006): symbol not found in flat namespace '_clagge_'
>>> 
```

Finally, I confirmed that loading still works correctly when bmad without the loading problem is used.
```
Python 3.12.2 | packaged by conda-forge | (main, Feb 16 2024, 20:54:21) [Clang 16.0.6 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from pytao import Tao
>>> Tao()
<pytao.interface_commands.Tao object at 0x103259520>
>>> 
```