### PR TITLE
CI: clone bmad for docs building; build docs on PRs

### DIFF
--- a/.github/actions/bmad-setup/action.yml
+++ b/.github/actions/bmad-setup/action.yml
@@ -1,0 +1,16 @@
+name: "bmad setup"
+description: "Clone the latest bmad"
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        repository: bmad-sim/bmad-ecosystem
+        fetch-depth: 1
+        path: bmad
+
+    - name: Set ACC_ROOT_DIR
+      shell: bash -l {0}
+      run: |
+        PYTAO_ROOT=/home/runner/work/pytao/pytao
+        echo "ACC_ROOT_DIR=$PYTAO_ROOT/bmad" >> $GITHUB_ENV

--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -1,5 +1,10 @@
 name: "conda setup"
 description: "Prepare the pytao conda environment"
+inputs:
+  python-version:
+    description: Python version
+    required: false
+    default: "3.9"
 runs:
   using: "composite"
   steps:
@@ -11,7 +16,7 @@ runs:
         use-mamba: true
         channels: conda-forge
         environment-file: dev-environment.yml
-        python-version: ${{ python-version }}
+        python-version: ${{ inputs.python-version }}
 
     - name: Show the installed packages
       shell: bash -l {0}

--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -1,0 +1,25 @@
+name: "conda setup"
+description: "Prepare the pytao conda environment"
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Mambaforge
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        miniforge-variant: Mambaforge
+        activate-environment: pytao-dev
+        use-mamba: true
+        channels: conda-forge
+        environment-file: dev-environment.yml
+        python-version: ${{ python-version }}
+
+    - name: Show the installed packages
+      shell: bash -l {0}
+      run: |
+        conda list
+
+    - name: Ensure importability
+      shell: bash -l {0}
+      run: |
+        cd /
+        python -c "import pytao"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,35 +23,16 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: actions/checkout@v4
-        with:
-          repository: bmad-sim/bmad-ecosystem
-          fetch-depth: 1
-          path: bmad
-
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: ./.github/actions/conda-setup
         with:
           python-version: ${{ matrix.python-version }}
-          mamba-version: "*"
-          channels: conda-forge
-          activate-environment: pytao-dev
-          environment-file: dev-environment.yml
 
-      - name: Setup Bmad
-        run: |
-          PYTAO_ROOT=/home/runner/work/pytao/pytao
-          echo "ACC_ROOT_DIR=$PYTAO_ROOT/bmad" >> $GITHUB_ENV
+      - uses: ./.github/actions/bmad-setup
 
       - name: Show conda environment packages
         shell: bash -l {0}
         run: |
           conda list
-
-      - name: Ensure importability
-        shell: bash -l {0}
-        run: |
-          cd /
-          python -c "import pytao"
 
       - name: Run Tests
         shell: bash -l {0}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -2,15 +2,12 @@ name: Publish Documentation
 
 on:
   push:
-    branches:
-      - "**"
   pull_request:
   schedule:
     - cron: "0 0 * * *" # every day at midnight
 
 jobs:
   deploy:
-    if: ${{ github.repository == 'bmad-sim/pytao' }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - "**"
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *" # every day at midnight
 
 jobs:
   deploy:
@@ -15,28 +18,32 @@ jobs:
         python-version: [3.12]
     steps:
       - uses: actions/checkout@v3
-      - uses: conda-incubator/setup-miniconda@v2
+
+      - uses: ./.github/actions/conda-setup
         with:
           python-version: ${{ matrix.python-version }}
-          mamba-version: "*"
-          channels: conda-forge
-          activate-environment: pytao-dev
-          environment-file: dev-environment.yml
+
+      - uses: ./.github/actions/bmad-setup
+
       - name: List mamba
         shell: bash -l {0}
         run: |
           mamba list
+
       - name: Execute notebooks
         shell: bash -l {0}
         run: |
           bash scripts/execute_notebooks.bash
+
       - name: Build Docs
         shell: bash -l {0}
         run: |
           mkdocs build
           zip -r pytao-examples.zip docs/examples/
           mv pytao-examples.zip ./site/assets/
+
       - name: Deploy to gh-pages
+        if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags') }}
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,7 +14,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: [3.12]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: ./.github/actions/conda-setup
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,13 +12,9 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: ./.github/actions/conda-setup
         with:
-          python-version: 3.12
-          mamba-version: "*"
-          channels: conda-forge
-          activate-environment: pytao-dev
-          environment-file: dev-environment.yml
+          python-version: "3.12"
 
       - name: Install pre-commit
         run: python -m pip install pre-commit


### PR DESCRIPTION
* Plotting example notebooks require Bmad to be available in `$ACC_ROOT_DIR`
   * Clone bmad for tests and docs
* Docs were only built on `master`
   * Now they are built on all branches/forks but only pushed on `master` (or a tag)
* Consolidate environment creation / bmad cloning in "composite" actions (`.github/actions`)
* Update some old actions versions