### PR TITLE
FIX: matplotlib floor plan aspect ratio

### DIFF
--- a/pytao/plotting/mpl.py
+++ b/pytao/plotting/mpl.py
@@ -383,6 +383,7 @@ def plot(graph: AnyGraph, ax: Optional[matplotlib.axes.Axes] = None) -> matplotl
         # ax.set_xticklabels([elem.info["label_name"] for elem in self.elements], rotation=90)
         ax.grid(visible=False)
     elif isinstance(graph, FloorPlanGraph):
+        ax.set_aspect("equal")
         for elem in graph.elements:
             if elem.shape is not None:
                 plot_floor_plan_shape(elem.shape, ax)


### PR DESCRIPTION
* Sets floor plan aspect ratio for matplotlib plots
    * Axes default is "box" for `adjustable` (https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.set_aspect.html)
    * We leave this unset so the user can tweak it, if desirable, when specifying their own `Axes` object