### PR TITLE
REF: unnamed pipe -> named pipe (FIFO) for SubprocessTao

### DIFF
--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v3
       with:
-        miniforge-variant: Mambaforge
+        miniforge-version: latest
         activate-environment: pytao-dev
         use-mamba: true
         channels: conda-forge

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.os }} Python ${{ matrix.python-version }}
+    name: ${{ matrix.os }} Python ${{ matrix.python-version }} (reuse=${{ matrix.subprocess-reuse }})
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -18,6 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
+        subprocess-reuse: ["0", "1"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -37,6 +38,7 @@ jobs:
       - name: Run Tests
         shell: bash -l {0}
         run: |
+          export TAO_REUSE_SUBPROCESS=${{ matrix.subprocess-reuse }}
           echo -e '## Test results\n\n```' >> "$GITHUB_STEP_SUMMARY"
           pytest -v --cov=pytao/ pytao/tests 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/pytao/plotting/mpl.py
+++ b/pytao/plotting/mpl.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import logging
 import pathlib
 import time
@@ -15,7 +16,6 @@ import matplotlib.pyplot as plt
 import matplotlib.text
 import matplotlib.ticker
 import numpy as np
-from pandas.core.frame import functools
 
 from . import floor_plan_shapes, layout_shapes, pgplot
 from .curves import PlotCurveLine, PlotCurveSymbols, PlotHistogram, TaoCurveSettings

--- a/pytao/subproc.py
+++ b/pytao/subproc.py
@@ -233,14 +233,12 @@ class _TaoPipe:
     instantiate another `_TaoPipe` instance.
     """
 
-    _lock: threading.Lock
     _init_queue: queue.Queue
     _subproc: subprocess.Popen
     _fifo: Optional[io.BufferedReader]
     _subprocess_monitor_thread: Optional[threading.Thread]
 
     def __init__(self):
-        self._lock = threading.Lock()
         self._init_queue = queue.Queue(maxsize=1)
         self._subproc = self._init_subprocess()
 
@@ -314,21 +312,20 @@ class _TaoPipe:
     def _init_subprocess(self) -> subprocess.Popen:
         """Initialize the Tao subprocess, the pipe, and monitor thread."""
         logger.debug("Initializing Tao subprocess")
-        with self._lock:
-            self._subprocess_monitor_thread = threading.Thread(
-                target=self._tao_subprocess,
-                daemon=True,
-            )
-            self._subprocess_monitor_thread.start()
-            start = self._init_queue.get()
-            if not isinstance(start, subprocess.Popen):
-                if isinstance(start, Exception):
-                    raise start
-                else:
-                    raise NotImplementedError(
-                        f"Failed to start Tao subprocess, unknown error: {type(start).__name__}"
-                    )
-            self._subproc = start
+        self._subprocess_monitor_thread = threading.Thread(
+            target=self._tao_subprocess,
+            daemon=True,
+        )
+        self._subprocess_monitor_thread.start()
+        start = self._init_queue.get()
+        if not isinstance(start, subprocess.Popen):
+            if isinstance(start, Exception):
+                raise start
+            else:
+                raise NotImplementedError(
+                    f"Failed to start Tao subprocess, unknown error: {type(start).__name__}"
+                )
+        self._subproc = start
 
         return self._subproc
 

--- a/pytao/subproc_main.py
+++ b/pytao/subproc_main.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import contextlib
 import logging
-import os
 import sys
 import traceback
 
@@ -25,7 +24,7 @@ from .tao_ctypes.util import filter_tao_messages_context
 logger = logging.getLogger(__name__)
 
 
-def _tao_subprocess(output_fd: int) -> None:
+def _tao_subprocess(output_fifo_filename: str) -> None:
     logger.debug("Tao subprocess handler started")
 
     tao = None
@@ -85,15 +84,15 @@ def _tao_subprocess(output_fd: int) -> None:
             }
             return error
 
-    with os.fdopen(output_fd, "wb") as output_pipe:
+    with open(output_fifo_filename, "wb") as output_fifo:
         while True:
             message = read_pickled_data(sys.stdin.buffer)
-            write_pickled_data(output_pipe, make_response(message))
+            write_pickled_data(output_fifo, make_response(message))
 
 
 if __name__ == "__main__":
     try:
-        output_fd = int(sys.argv[1])
+        output_fifo_filename = sys.argv[1]
     except (IndexError, ValueError):
         print(
             f"Usage: {sys.executable} {__file__} (output_file_descriptor)",
@@ -102,7 +101,7 @@ if __name__ == "__main__":
         exit(1)
 
     try:
-        _tao_subprocess(output_fd)
+        _tao_subprocess(output_fifo_filename)
     except (TaoDisconnectedError, OSError):
         exit(1)
     except KeyboardInterrupt:

--- a/pytao/tao_ctypes/util.py
+++ b/pytao/tao_ctypes/util.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import contextlib
 import contextvars
+import importlib
+import sys
 import textwrap
 from dataclasses import dataclass, field
 from typing import Dict, FrozenSet, Iterable, List, Optional, Set, Tuple
@@ -633,3 +635,24 @@ def simple_lat_table(tao, ix_universe=1, ix_branch=0, which="model", who="twiss"
         if name == "END":
             break
     return ele_table
+
+
+def import_by_name(clsname: str):
+    """
+    Import the given object by name.
+
+    Parameters
+    ----------
+    clsname : str
+        The module path to find the class e.g.
+        ``"pytao.Tao"``
+    """
+    module, cls = clsname.rsplit(".", 1)
+    if module not in sys.modules:
+        importlib.import_module(module)
+
+    mod = sys.modules[module]
+    try:
+        return getattr(mod, cls)
+    except AttributeError:
+        raise ImportError(f"Unable to import {clsname!r} from module {module!r}")

--- a/pytao/tests/conftest.py
+++ b/pytao/tests/conftest.py
@@ -79,7 +79,7 @@ if not REUSE_SUBPROCESS:
     class TaoTestStartup(TaoStartup):
         @contextlib.contextmanager
         def run_context(self, use_subprocess: bool = False):
-            with capture(by_command={"init": ["tao_find_plots"]}):
+            with filter_tao_messages_context(by_command={"init": ["tao_find_plots"]}):
                 # super() will close the subprocess for us
                 with super().run_context(use_subprocess=use_subprocess) as tao:
                     yield tao

--- a/pytao/tests/conftest.py
+++ b/pytao/tests/conftest.py
@@ -75,7 +75,14 @@ if "PYTEST_XDIST_WORKER" in os.environ or os.environ.get("ACTIONS_RUNNER_DEBUG",
 
 
 if not REUSE_SUBPROCESS:
-    TaoTestStartup = TaoStartup
+
+    class TaoTestStartup(TaoStartup):
+        @contextlib.contextmanager
+        def run_context(self, use_subprocess: bool = False):
+            with capture(by_command={"init": ["tao_find_plots"]}):
+                # super() will close the subprocess for us
+                with super().run_context(use_subprocess=use_subprocess) as tao:
+                    yield tao
 else:
 
     class TaoTestStartup(TaoStartup):

--- a/pytao/tests/test_subproc.py
+++ b/pytao/tests/test_subproc.py
@@ -1,25 +1,135 @@
+from __future__ import annotations
+
 import time
+from typing import Any, Callable, Dict, Generator
 
 import numpy as np
 import pytest
 
 from .. import SubprocessTao
-from ..subproc import TaoDisconnectedError
+from ..interface_commands import Tao
+from ..subproc import SupportedKwarg, TaoDisconnectedError
+from ..tao_ctypes.util import TaoCommandError
 
 
 def test_crash_and_recovery() -> None:
     init = "-init $ACC_ROOT_DIR/regression_tests/pipe_test/csr_beam_tracking/tao.init -noplot"
-    tao = SubprocessTao(init=init)
-    # tao.init("-init regression_tests/pipe_test/tao.init_plot_line -external_plotting")
-    bunch1 = tao.bunch1(ele_id="end", coordinate="x", which="model", ix_bunch="1")
-    print("bunch1=", bunch1)
+    with SubprocessTao(init=init) as tao:
+        # tao.init("-init regression_tests/pipe_test/tao.init_plot_line -external_plotting")
+        bunch1 = tao.bunch1(ele_id="end", coordinate="x", which="model", ix_bunch="1")
+        print("bunch1=", bunch1)
 
-    with pytest.raises(TaoDisconnectedError):
-        # Close the pipe earlier than expected
-        tao._pipe.send_receive("quit", "", raises=True)
-    time.sleep(0.5)
+        assert tao._subproc_pipe_ is not None
 
-    print("Re-initializing:")
-    tao.init(init)
-    retry = tao.bunch1(ele_id="end", coordinate="x", which="model", ix_bunch="1")
-    assert np.allclose(bunch1, retry)
+        with pytest.raises(TaoDisconnectedError):
+            # Close the pipe earlier than expected
+            tao._subproc_pipe_.send_receive("quit", "", raises=True)
+        time.sleep(0.5)
+
+        print("Re-initializing:")
+        tao.init(init)
+        retry = tao.bunch1(ele_id="end", coordinate="x", which="model", ix_bunch="1")
+        assert np.allclose(bunch1, retry)
+
+
+def tao_custom_command(tao: Tao, value: Any):
+    assert isinstance(tao, Tao)
+    if isinstance(value, bool):
+        return 23
+    if isinstance(value, (int, np.ndarray)):
+        return value + 1
+    return value
+
+
+@pytest.fixture(scope="module")
+def subproc_tao() -> Generator[SubprocessTao, None, None]:
+    with SubprocessTao(
+        init_file="$ACC_ROOT_DIR/regression_tests/pipe_test/csr_beam_tracking/tao.init",
+        noplot=True,
+    ) as tao:
+        yield tao
+
+
+@pytest.mark.parametrize(
+    ("func", "kwargs", "expected_result"),
+    [
+        pytest.param(
+            tao_custom_command,
+            {"value": 3},
+            4,
+            id="int",
+        ),
+        pytest.param(
+            tao_custom_command,
+            {"value": np.zeros(3)},
+            np.ones(3),
+            id="ndarray",
+        ),
+        pytest.param(
+            tao_custom_command,
+            {"value": {"a": np.zeros(3), "b": {"c": np.ones(3)}}},
+            {"a": np.zeros(3), "b": {"c": np.ones(3)}},
+            id="nested-ndarray",
+        ),
+        pytest.param(
+            tao_custom_command,
+            {"value": "value"},
+            "value",
+            id="str",
+        ),
+        pytest.param(
+            tao_custom_command,
+            {"value": True},
+            23,
+            id="bool",
+        ),
+        pytest.param(
+            tao_custom_command,
+            {"value": 1.0},
+            1.0,
+            id="float",
+        ),
+        pytest.param(
+            tao_custom_command,
+            {"value": [1.0, {"a": np.zeros(3)}]},
+            [1.0, {"a": np.zeros(3)}],
+            id="list",
+        ),
+        pytest.param(
+            tao_custom_command,
+            {"value": {1.0, 2.0, 3.0}},
+            {1.0, 2.0, 3.0},
+            id="set",
+        ),
+        pytest.param(
+            tao_custom_command,
+            {"value": (1.0, {"a": np.zeros(3)})},
+            (1.0, {"a": np.zeros(3)}),
+            id="tuple",
+        ),
+    ],
+)
+def test_custom_command(
+    subproc_tao: SubprocessTao,
+    func: Callable,
+    kwargs: Dict[str, SupportedKwarg],
+    expected_result: Any,
+) -> None:
+    res = subproc_tao.subprocess_call(func, **kwargs)
+    if isinstance(expected_result, np.ndarray):
+        assert np.all(res == expected_result)
+    elif "array(" in str(expected_result):
+        # Lazily check the result's string equality
+        assert str(res) == str(expected_result)
+    else:
+        assert res == expected_result
+
+
+def failure_func(tao: Tao, **kwargs):
+    raise ValueError(f"test got kwargs: {kwargs}")
+
+
+def test_custom_command_exception(subproc_tao: SubprocessTao) -> None:
+    with pytest.raises(TaoCommandError) as ex:
+        subproc_tao.subprocess_call(failure_func, a=3)
+    assert "ValueError: test got kwargs: {'a': 3}" in str(ex.value)


### PR DESCRIPTION
## Context

~**Based** on #95 as that PR cleans up a lot of subprocess-related handling. It needs to be decided on/merged first.~

* We found instability when using `SubprocessTao` in `multiprocessing.Pool`s
    * Occasionally this would raise `OSError: Bad file descriptor` (2-10% of the time)
    * It seems as if there are race conditions with `os.pipe()` and inherited file descriptors in subprocesses, such that they can fight with one another. It never happens on the first initialization from what I've seen.
* Utilizing [named pipes](https://en.wikipedia.org/wiki/Named_pipe), as in this PR, appears to not have these issues
    * In multiple local runs, this has had a 0% failure rate (1000s of runs, 10 multiprocessing subprocesses)
* I think this is a bit cleaner of a solution
    * Even if we figured out how to address the `pipe()` issue, I think I'd like to move forward with this anyway
* Bonus: custom commands for `SubprocessTao`
   * Run _importable_ callables in the subprocess and get the result by way of `tao.subprocess_call(function, **kwargs)`
   * The `tao` keyword argument is inserted automatically