### PR TITLE
FIX: SBend line intersection code caused large vertex values in shapes

### DIFF
--- a/pytao/plotting/floor_plan_shapes.py
+++ b/pytao/plotting/floor_plan_shapes.py
@@ -251,12 +251,12 @@ def _sbend_intersection_to_patch(
     # corresponding control points for a quadratic Bezier curve that
     # passes through the corners and arc midpoint
     top_cp = (
-        2 * (top[0]) - 0.5 * (c1[0]) - 0.5 * (c2[0]),
-        2 * (top[1]) - 0.5 * (c1[1]) - 0.5 * (c2[1]),
+        2 * top[0] - 0.5 * c1[0] - 0.5 * c2[0],
+        2 * top[1] - 0.5 * c1[1] - 0.5 * c2[1],
     )
     bottom_cp = (
-        2 * (bottom[0]) - 0.5 * (c3[0]) - 0.5 * (c4[0]),
-        2 * (bottom[1]) - 0.5 * (c3[1]) - 0.5 * (c4[1]),
+        2 * bottom[0] - 0.5 * c3[0] - 0.5 * c4[0],
+        2 * bottom[1] - 0.5 * c3[1] - 0.5 * c4[1],
     )
 
     return PlotPatchSbend(

--- a/pytao/plotting/util.py
+++ b/pytao/plotting/util.py
@@ -55,7 +55,7 @@ def intersect(L1: Line, L2: Line) -> Intersection:
     Dx = L1[2] * L2[1] - L1[1] * L2[2]
     Dy = L1[0] * L2[2] - L1[2] * L2[0]
 
-    if D == 0:
+    if np.isclose(D, 0.0):
         raise NoIntersectionError()
 
     x = Dx / D


### PR DESCRIPTION
Example:

This SBend:
```
SBend(x1=35.446621, x2=35.760492, y1=12.211122, y2=12.211122, off1=0.15, off2=0.15, angle_start=-3.7793352e-14, angle_end=-3.7793352e-14, rel_angle_start=-0.087266463, rel_angle_end=0.25460883, line_width=1.0, color='red', name='')
```

Caused large plot patches to be generated:

```
PlotPatchSbend(edgecolor=None, facecolor='green', color=None, linewidth=None, linestyle=None, antialiased=None, hatch=None, fill=True, capstyle=None, joinstyle=None, alpha=0.5, spline1=((35.43354763852804, 12.360551204708528), (-33.571610834509784, -1617764288046775.0), (35.722711969725886, 12.356286283873434)), spline2=((35.79827203027411, 12.065957716126565), (-33.62246422625584, -1617764288046774.0), (35.45969436147196, 12.06169279529147)))
```

As the line intersection found was near negative infinity.

The naive original code this was based on assumed the slope would be equal to 0.0 (a poor assumption), and this PR just switches it up to be approximately 0.0. Without an intersection, the SBend will be rendered as just lines and not curved patches.