### PR TITLE
 BLD: remove deprecated/invalid options in pyproject

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
         args: ["--maxkb=100000"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.0
+    rev: v0.8.4
     hooks:
       - id: ruff
         args: ["--config", "pyproject.toml"]
@@ -47,7 +47,7 @@ repos:
       - id: jupyter-notebook-clear-output
         name: jupyter-notebook-jupyter-clear
         files: \.ipynb$
-        stages: [commit]
+        stages: [pre-commit]
         language: system
         entry: jupyter nbconvert --ClearOutputPreprocessor.enabled=True --inplace
         # exclude: "^.*().ipynb$"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,6 @@ Documentation = "https://bmad-sim.github.io/pytao/"
 Repository = "https://github.com/bmad-sim/pytao"
 Issues = "https://github.com/bmad-sim/pytao/issues"
 
-[options]
-zip_safe = false
-include_package_data = true
-
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["pytao*"]


### PR DESCRIPTION
* Removes `options.zip_safe` (wrong section / deprecated) and `options.include_package_data` (wrong section and now the default anyway)
* Reformats the pyproject.toml file as well for good measure
* Migrates and update pre-commit configuration
