### PR TITLE
DOC: PyTao plotting issues that arise from `-noplot`

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -105,6 +105,31 @@ In [1]: tao.plot("beta")
 In [2]: plt.show()
 ```
 
+## PyTao plotting and startup scripts
+
+When PyTao is instructed to use its Matplotlib or Bokeh backends, it configures
+the underlying Tao instance to work in `-noplot` mode. If you have plotting
+calls in your startup script, you may see warnings and errors that prevent you
+from using your Tao object.
+
+Consider these alternatives:
+
+1. Use `-nostartup` (or `Tao(nostartup=True)`) to avoid using your startup file.
+2. Consider making a "no plot" alternative startup file.
+3. Use PyTao error filtering to ignore errors coming from specific Tao functions at startup:
+
+   ```python
+   import matplotlib.pyplot as plt
+   from pytao import Tao, filter_tao_messages_context
+
+
+   with filter_tao_messages_context(functions=["tao_find_plots"]):
+       tao = Tao(init_file="tao.init", plot="mpl")
+
+   tao.plot("beta")
+   plt.show()
+   ```
+
 ## PyTao (deprecated/experimental) GUI
 
 Start the experimental (and mostly unsupported/deprecated) GUI by using the following:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,14 @@ pytao-gui = "pytao.gui.__main__:main"
 # Currently it's expected that users install via conda;
 # however, a pip-based installation should work as well.
 # `pip install .[all]`
-all = ["h5py", "numpy", "pexpect", "matplotlib", "openpmd-beamphysics"]
+all = [
+  "h5py",
+  "numpy",
+  "pexpect",
+  "matplotlib",
+  "openpmd-beamphysics",
+  "pydantic>=2",
+]
 
 [project.urls]
 Homepage = "https://www.classe.cornell.edu/bmad/tao.html"


### PR DESCRIPTION
Closes #119 

Tao can throw errors with plotting during initialization when running users' startup scripts that interact with plots. PyTao forces the underlying Tao to use `-noplot` when using Matplotlib/Bokeh backends.