### PR TITLE
PERF: use array buffer methods for plot curve line/symbol data retrieval

### DIFF
--- a/pytao/plotting/plot.py
+++ b/pytao/plotting/plot.py
@@ -232,19 +232,22 @@ class PlotCurve:
         curve_info.pop("ix_ele_ref_track", None)
 
         try:
-            points = [
-                (line["x"], line["y"])
-                for line in tao.plot_line(region_name, graph_name, curve_name) or []
-            ]
+            points = list(
+                zip(
+                    tao.plot_line(region_name, graph_name, curve_name, x_or_y="x"),
+                    tao.plot_line(region_name, graph_name, curve_name, x_or_y="y"),
+                )
+            )
         except RuntimeError:
             points = []
 
         try:
-            symbol_points = [
-                (sym["x_symb"], sym["y_symb"])
-                for sym in tao.plot_symbol(region_name, graph_name, curve_name, x_or_y="")
-                or []
-            ]
+            symbol_points = list(
+                zip(
+                    tao.plot_symbol(region_name, graph_name, curve_name, x_or_y="x"),
+                    tao.plot_symbol(region_name, graph_name, curve_name, x_or_y="y"),
+                )
+            )
         except RuntimeError:
             symbol_points = []
 

--- a/pytao/plotting/plot.py
+++ b/pytao/plotting/plot.py
@@ -1407,7 +1407,15 @@ class GraphManager(ABC):
         self.to_place.pop(region_name, None)
 
         logger.debug(f"Placing {template_name} in {region_name}")
-        self.tao.cmd(f"place -no_buffer {region_name} {template_name}")
+        self.tao.cmd(
+            "; ".join(
+                (
+                    # Ensure overlapping plots won't delete existing ones
+                    "set plot_page delete_overlapping_plots = F",
+                    f"place -no_buffer {region_name} {template_name}",
+                ),
+            )
+        )
         return region_name
 
     def place(


### PR DESCRIPTION
## Changes

* Use `tao.plot_line()` with `x_or_y` to take advantage of the `tao_c_interface_com%c_real` array buffer.
* Set `plot_page%delete_overlapping_plots` to `False` to ensure plot regions don't affect one another

## Background

The current `master` branch uses `tao.plot_line()` to retrieve both X- and Y- positions of the given plot curve.
This offers a significant speed-up for larger lattices. 

For example, making plots of a lattice with a few thousand elements may get a considerable speed-up with pytao plotting (i.e., matplotlib or bokeh) after this PR is merged:

`master` under the hood uses this:
```
In [1]: %timeit tao.plot_line("r13", "g", "a", x_or_y="")
44 ms ± 932 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

This PR uses this:
```
In [14]: %timeit tao.plot_line("r13", "g", "a", x_or_y="x")
983 μs ± 52.6 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [17]: %timeit tao.plot_line("r13", "g", "a", x_or_y="y")
1.07 ms ± 28.7 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

For a single curve, this PR would accelerate plots (and interactive updates of those plots) by ~22x (`=44/(1+0.9) ms`).
This speed-up applies to every curve displayed, so applications with many curves will see a much more obvious improvement.