### PR TITLE
Fix FODO notebook

### DIFF
--- a/docs/examples/fodo.ipynb
+++ b/docs/examples/fodo.ipynb
@@ -18,14 +18,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e9cad9ba-e9a5-40dd-9b92-73186a2b8ae4",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:14.546688Z",
-     "iopub.status.busy": "2024-08-08T19:06:14.546280Z",
-     "iopub.status.idle": "2024-08-08T19:06:14.967243Z",
-     "shell.execute_reply": "2024-08-08T19:06:14.966907Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from pytao import Tao\n",
@@ -40,14 +33,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "792aef00-8f6b-4e11-9737-11addb070c10",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:14.968840Z",
-     "iopub.status.busy": "2024-08-08T19:06:14.968728Z",
-     "iopub.status.idle": "2024-08-08T19:06:15.032632Z",
-     "shell.execute_reply": "2024-08-08T19:06:15.032360Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "tao = Tao(\n",
@@ -59,14 +45,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "da32a879-df05-4826-9b7a-516d8629be77",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:15.034044Z",
-     "iopub.status.busy": "2024-08-08T19:06:15.033966Z",
-     "iopub.status.idle": "2024-08-08T19:06:15.035926Z",
-     "shell.execute_reply": "2024-08-08T19:06:15.035715Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def add_info(d):\n",
@@ -84,14 +63,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f5a7188a-68c9-4b94-af92-a55643f45f9b",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:15.037084Z",
-     "iopub.status.busy": "2024-08-08T19:06:15.037016Z",
-     "iopub.status.idle": "2024-08-08T19:06:15.039645Z",
-     "shell.execute_reply": "2024-08-08T19:06:15.039427Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%tao\n",
@@ -110,14 +82,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "85c21987-a7b5-42d5-a5f5-7a65dce11a31",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:15.040927Z",
-     "iopub.status.busy": "2024-08-08T19:06:15.040856Z",
-     "iopub.status.idle": "2024-08-08T19:06:15.045221Z",
-     "shell.execute_reply": "2024-08-08T19:06:15.044995Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def set_kx(k1):\n",
@@ -144,14 +109,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c602c82b-fac0-4882-8dd9-e0583a3fa20c",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:15.046436Z",
-     "iopub.status.busy": "2024-08-08T19:06:15.046351Z",
-     "iopub.status.idle": "2024-08-08T19:06:15.064727Z",
-     "shell.execute_reply": "2024-08-08T19:06:15.064526Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Scan k1\n",
@@ -171,14 +129,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "2357ea31-2055-491c-9b33-566b06a95984",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:15.065872Z",
-     "iopub.status.busy": "2024-08-08T19:06:15.065781Z",
-     "iopub.status.idle": "2024-08-08T19:06:15.067479Z",
-     "shell.execute_reply": "2024-08-08T19:06:15.067278Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Reshape data\n",
@@ -198,14 +149,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d2b18bee-f598-45dd-bb23-4a0f0d484a9a",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:15.068559Z",
-     "iopub.status.busy": "2024-08-08T19:06:15.068473Z",
-     "iopub.status.idle": "2024-08-08T19:06:15.070212Z",
-     "shell.execute_reply": "2024-08-08T19:06:15.070009Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "DAT.keys()"
@@ -215,14 +159,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "652a3472-d726-44be-9305-5441dbd71e4f",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:15.071288Z",
-     "iopub.status.busy": "2024-08-08T19:06:15.071210Z",
-     "iopub.status.idle": "2024-08-08T19:06:15.470813Z",
-     "shell.execute_reply": "2024-08-08T19:06:15.470535Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "for key in KEYS:\n",
@@ -236,14 +173,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "0e7b5796-2ab8-4ac2-ad85-4e09d6d27c20",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:15.472236Z",
-     "iopub.status.busy": "2024-08-08T19:06:15.472132Z",
-     "iopub.status.idle": "2024-08-08T19:06:15.474026Z",
-     "shell.execute_reply": "2024-08-08T19:06:15.473809Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%tao\n",
@@ -264,14 +194,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e27c52bd-9cf7-42e8-ab74-dece4569cdb5",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:15.475296Z",
-     "iopub.status.busy": "2024-08-08T19:06:15.475206Z",
-     "iopub.status.idle": "2024-08-08T19:06:15.479544Z",
-     "shell.execute_reply": "2024-08-08T19:06:15.479337Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def set_k(k1, k2):\n",
@@ -298,14 +221,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "0847d120-cf80-42d8-8ee8-1afa03e8fb52",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:15.480709Z",
-     "iopub.status.busy": "2024-08-08T19:06:15.480624Z",
-     "iopub.status.idle": "2024-08-08T19:06:15.483526Z",
-     "shell.execute_reply": "2024-08-08T19:06:15.483326Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "set_k(1, 1)"
@@ -315,14 +231,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "be51cc3a-f022-4824-ac0a-499845f1ec0a",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:15.484714Z",
-     "iopub.status.busy": "2024-08-08T19:06:15.484640Z",
-     "iopub.status.idle": "2024-08-08T19:06:15.486483Z",
-     "shell.execute_reply": "2024-08-08T19:06:15.486309Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "n1 = 50\n",
@@ -340,12 +249,6 @@
    "execution_count": null,
    "id": "3bfca083-1314-42f1-8399-3d1e26ab95fa",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:15.487592Z",
-     "iopub.status.busy": "2024-08-08T19:06:15.487509Z",
-     "iopub.status.idle": "2024-08-08T19:06:17.071921Z",
-     "shell.execute_reply": "2024-08-08T19:06:17.071660Z"
-    },
     "tags": []
    },
    "outputs": [],
@@ -369,14 +272,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "01622876-ab36-4cff-82e2-2dff1dbb1a29",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:17.073209Z",
-     "iopub.status.busy": "2024-08-08T19:06:17.073114Z",
-     "iopub.status.idle": "2024-08-08T19:06:17.076602Z",
-     "shell.execute_reply": "2024-08-08T19:06:17.076391Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Reshape data\n",
@@ -405,14 +301,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "66105948-267e-4a21-a3f0-375b13adce33",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:17.077780Z",
-     "iopub.status.busy": "2024-08-08T19:06:17.077694Z",
-     "iopub.status.idle": "2024-08-08T19:06:17.079335Z",
-     "shell.execute_reply": "2024-08-08T19:06:17.079129Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "NICE = {}\n",
@@ -430,14 +319,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e9689fc2-c433-468d-99aa-594ae07038a2",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:17.080494Z",
-     "iopub.status.busy": "2024-08-08T19:06:17.080404Z",
-     "iopub.status.idle": "2024-08-08T19:06:17.280925Z",
-     "shell.execute_reply": "2024-08-08T19:06:17.280673Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# fig, ax = plt.subplots(figsize=(10,8))\n",
@@ -473,14 +355,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "bd151056-66eb-4f4a-ad07-39b3106bc445",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:17.282262Z",
-     "iopub.status.busy": "2024-08-08T19:06:17.282184Z",
-     "iopub.status.idle": "2024-08-08T19:06:17.287644Z",
-     "shell.execute_reply": "2024-08-08T19:06:17.287383Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def optimize(beta_a, beta_b):\n",
@@ -516,14 +391,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "bdf6e2cb-1e55-4141-b37f-b21d3b0bdba6",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:17.288860Z",
-     "iopub.status.busy": "2024-08-08T19:06:17.288789Z",
-     "iopub.status.idle": "2024-08-08T19:06:17.290716Z",
-     "shell.execute_reply": "2024-08-08T19:06:17.290506Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Check merit\n",
@@ -534,14 +402,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4ec11177-a124-4ede-afd5-6279a1688dae",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:17.291931Z",
-     "iopub.status.busy": "2024-08-08T19:06:17.291860Z",
-     "iopub.status.idle": "2024-08-08T19:06:17.294168Z",
-     "shell.execute_reply": "2024-08-08T19:06:17.293954Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Check that the optimization worked\n",
@@ -554,14 +415,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "30c1e68c-5868-4b67-b8f4-c90b4fc8c36a",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:17.295366Z",
-     "iopub.status.busy": "2024-08-08T19:06:17.295294Z",
-     "iopub.status.idle": "2024-08-08T19:06:17.297728Z",
-     "shell.execute_reply": "2024-08-08T19:06:17.297522Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# These are the K\n",
@@ -584,14 +438,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e2b1c62c-86df-47fb-b9cb-34fb206a5693",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:17.298945Z",
-     "iopub.status.busy": "2024-08-08T19:06:17.298874Z",
-     "iopub.status.idle": "2024-08-08T19:06:17.301339Z",
-     "shell.execute_reply": "2024-08-08T19:06:17.301118Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "tao.cmd(\n",
@@ -608,14 +455,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "cf9ea816-a8ee-4269-99e3-a0226983e3b6",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:17.302511Z",
-     "iopub.status.busy": "2024-08-08T19:06:17.302437Z",
-     "iopub.status.idle": "2024-08-08T19:06:17.304355Z",
-     "shell.execute_reply": "2024-08-08T19:06:17.304154Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "T = tao.ele_twiss(\"Q1\")\n",
@@ -636,14 +476,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7eb23d45-05d2-46e6-9929-9596cfc7e00a",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:17.305599Z",
-     "iopub.status.busy": "2024-08-08T19:06:17.305529Z",
-     "iopub.status.idle": "2024-08-08T19:06:17.309063Z",
-     "shell.execute_reply": "2024-08-08T19:06:17.308846Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from pytao.misc.markers import make_markers"
@@ -653,14 +486,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "bf23526d-8a29-4b88-ac0c-a3acfac6de82",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:17.310232Z",
-     "iopub.status.busy": "2024-08-08T19:06:17.310161Z",
-     "iopub.status.idle": "2024-08-08T19:06:17.327674Z",
-     "shell.execute_reply": "2024-08-08T19:06:17.327450Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "?make_markers"
@@ -670,14 +496,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "07e31b2e-14a2-4d14-9629-28033c0712b8",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:17.328887Z",
-     "iopub.status.busy": "2024-08-08T19:06:17.328817Z",
-     "iopub.status.idle": "2024-08-08T19:06:17.331580Z",
-     "shell.execute_reply": "2024-08-08T19:06:17.331391Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "smax = 20.0  # m\n",
@@ -695,14 +514,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3944eae5-6328-4b67-bad9-5cecca431350",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:17.332667Z",
-     "iopub.status.busy": "2024-08-08T19:06:17.332590Z",
-     "iopub.status.idle": "2024-08-08T19:06:17.334974Z",
-     "shell.execute_reply": "2024-08-08T19:06:17.334793Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Make a lattice and write to a local file\n",
@@ -729,14 +541,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "24532821-6d8d-4ace-84e7-21748ee98af0",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:17.336071Z",
-     "iopub.status.busy": "2024-08-08T19:06:17.336004Z",
-     "iopub.status.idle": "2024-08-08T19:06:17.384939Z",
-     "shell.execute_reply": "2024-08-08T19:06:17.384686Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Run with this lattice\n",
@@ -749,14 +554,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a2f0a836-03f8-4fc9-99fb-0a3f31ced8ba",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:17.386182Z",
-     "iopub.status.busy": "2024-08-08T19:06:17.386115Z",
-     "iopub.status.idle": "2024-08-08T19:06:17.388027Z",
-     "shell.execute_reply": "2024-08-08T19:06:17.387817Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "f\"-init $ACC_ROOT_DIR/bmad-doc/tao_examples/fodo/tao.init -lat {latfile} -noplot\""
@@ -765,22 +563,42 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ed805f78-89b6-4d87-bbe3-8ce9ae649238",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%tao\n",
+    "sho beam"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "b29e148b-053a-4666-90d7-be7b47ee4b86",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:17.389116Z",
-     "iopub.status.busy": "2024-08-08T19:06:17.389046Z",
-     "iopub.status.idle": "2024-08-08T19:06:17.900303Z",
-     "shell.execute_reply": "2024-08-08T19:06:17.900025Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Toggle the beam on and off\n",
+    "tao.cmd('set beam dump_file = beam_dump.h5')\n",
+    "tao.cmd('set beam dump_at = *')\n",
     "tao.cmd(\"set beam_init n_particle = 1000\")\n",
+    "tao.cmd(\"set beam_init bunch_charge =1e-15\")\n",
+    "tao.cmd(\"set beam_init a_norm_emit = 1e-6\")\n",
+    "tao.cmd(\"set beam_init b_norm_emit = 1e-6\")\n",
     "tao.cmd('set beam track_start = beginning')\n",
     "tao.cmd('set beam track_end = end')\n",
     "tao.cmd(\"set global track_type = beam;set global track_type = single\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b699cd99-7d97-44b3-b80f-19ef587e7d93",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%tao\n",
+    "sho beam"
    ]
   },
   {
@@ -795,14 +613,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8047a9d2-d92d-4dcc-af75-3d98f9bd53a9",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:17.901703Z",
-     "iopub.status.busy": "2024-08-08T19:06:17.901608Z",
-     "iopub.status.idle": "2024-08-08T19:06:18.484495Z",
-     "shell.execute_reply": "2024-08-08T19:06:18.484154Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import h5py\n",
@@ -827,14 +638,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "067d3f0a-7a7b-4c97-bb24-05d75222df4d",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:18.486238Z",
-     "iopub.status.busy": "2024-08-08T19:06:18.486115Z",
-     "iopub.status.idle": "2024-08-08T19:06:19.565424Z",
-     "shell.execute_reply": "2024-08-08T19:06:19.565145Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "skip = 1  # make larger for faster plotting\n",
@@ -875,14 +679,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "78e1f010-5bef-47a9-af3c-7d488df46717",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:19.568406Z",
-     "iopub.status.busy": "2024-08-08T19:06:19.568305Z",
-     "iopub.status.idle": "2024-08-08T19:06:19.681082Z",
-     "shell.execute_reply": "2024-08-08T19:06:19.680829Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "k1 = \"sigma_x\"\n",
@@ -912,14 +709,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3bf14254-fca3-4a2d-82b6-48f65774398b",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2024-08-08T19:06:19.682432Z",
-     "iopub.status.busy": "2024-08-08T19:06:19.682343Z",
-     "iopub.status.idle": "2024-08-08T19:06:20.069134Z",
-     "shell.execute_reply": "2024-08-08T19:06:20.067167Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Cleanup\n",
@@ -945,7 +735,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.13.3"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
This adds lines to fix the fodo notebook:

```
tao.cmd('set beam dump_file = beam_dump.h5')
tao.cmd('set beam dump_at = *')
tao.cmd("set beam_init bunch_charge =1e-15")
tao.cmd("set beam_init a_norm_emit = 1e-6")
tao.cmd("set beam_init b_norm_emit = 1e-6")
```

I'm not sure what changed that caused this to stop working.