### PR TITLE
FIX: SubprocessTao progress bar

### DIFF
--- a/pytao/_shmem_compat.py
+++ b/pytao/_shmem_compat.py
@@ -1,0 +1,52 @@
+# Reference: https://github.com/python/cpython/issues/82300#issuecomment-2169035092
+
+import sys
+import threading
+from multiprocessing import resource_tracker as _mprt
+from multiprocessing import shared_memory as _mpshm
+
+
+if sys.version_info >= (3, 13):
+    SharedMemory = _mpshm.SharedMemory
+else:
+
+    class SharedMemory(_mpshm.SharedMemory):
+        __lock = threading.Lock()
+
+        def __init__(
+            self,
+            name: str | None = None,
+            create: bool = False,
+            size: int = 0,
+            *,
+            track: bool = True,
+        ) -> None:
+            self._track = track
+
+            # if tracking, normal init will suffice
+            if track:
+                return super().__init__(name=name, create=create, size=size)
+
+            # lock so that other threads don't attempt to use the
+            # register function during this time
+            with self.__lock:
+                # temporarily disable registration during initialization
+                orig_register = _mprt.register
+                _mprt.register = self.__tmp_register
+
+                # initialize; ensure original register function is
+                # re-instated
+                try:
+                    super().__init__(name=name, create=create, size=size)
+                finally:
+                    _mprt.register = orig_register
+
+        @staticmethod
+        def __tmp_register(*args, **kwargs) -> None:
+            return
+
+        def unlink(self) -> None:
+            if _mpshm._USE_POSIX and self._name:
+                _mpshm._posixshmem.shm_unlink(self._name)
+                if self._track:
+                    _mprt.unregister(self._name, "shared_memory")

--- a/pytao/subproc.py
+++ b/pytao/subproc.py
@@ -12,12 +12,12 @@ import sys
 import tempfile
 import threading
 from collections.abc import Callable
-from multiprocessing.shared_memory import SharedMemory
 from typing import Any, Literal, Optional, Union, cast
 
 import numpy as np
 from typing_extensions import NotRequired, TypedDict, override
 
+from ._shmem_compat import SharedMemory
 from .errors import TaoCommandError, TaoInitializationError
 from .startup import TaoStartup
 from .tao import Tao
@@ -152,7 +152,9 @@ class _TaoPipe:
     def __init__(self, env: dict[str, str]):
         self._init_queue = queue.Queue(maxsize=1)
         self._subprocess_env = env.copy()
-        self._beam_track_shm = SharedMemory(create=True, size=_BEAM_TRACK_SHM_SIZE)
+        self._beam_track_shm = SharedMemory(
+            create=True, size=_BEAM_TRACK_SHM_SIZE, track=False
+        )
         struct.pack_into(_BEAM_TRACK_SHM_FMT, self._beam_track_shm.buf, 0, -1)
         self._subproc = self._init_subprocess()
 

--- a/pytao/subproc.py
+++ b/pytao/subproc.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 import tempfile
 import threading
+import weakref
 from collections.abc import Callable
 from typing import Any, Literal, Optional, Union, cast
 
@@ -134,6 +135,18 @@ _BEAM_TRACK_SHM_FMT = "i"
 _BEAM_TRACK_SHM_SIZE = struct.calcsize(_BEAM_TRACK_SHM_FMT)
 
 
+def _cleanup_shm(shm: SharedMemory) -> None:
+    """weakref finalize callback to clean up shared memory."""
+    try:
+        shm.close()
+    except Exception:
+        pass
+    try:
+        shm.unlink()
+    except Exception:
+        pass
+
+
 class _TaoPipe:
     """
     Tao subprocess Pipe helper.
@@ -152,10 +165,11 @@ class _TaoPipe:
     def __init__(self, env: dict[str, str]):
         self._init_queue = queue.Queue(maxsize=1)
         self._subprocess_env = env.copy()
-        self._beam_track_shm = SharedMemory(
-            create=True, size=_BEAM_TRACK_SHM_SIZE, track=False
-        )
-        struct.pack_into(_BEAM_TRACK_SHM_FMT, self._beam_track_shm.buf, 0, -1)
+        shm = SharedMemory(create=True, size=_BEAM_TRACK_SHM_SIZE, track=False)
+        if shm.buf is not None:
+            struct.pack_into(_BEAM_TRACK_SHM_FMT, shm.buf, 0, -1)
+        self._beam_track_shm = shm
+        weakref.finalize(self, _cleanup_shm, shm)
         self._subproc = self._init_subprocess()
 
     @property
@@ -170,19 +184,21 @@ class _TaoPipe:
             self.send_receive("quit", "", propagate_exceptions=False)
         except TaoDisconnectedError:
             pass
-        self._close_beam_track_shm()
+        finally:
+            _cleanup_shm(self._beam_track_shm)
 
     def close_forcefully(self) -> None:
         """Close the pipe."""
-        self._subproc.terminate()
-        self._close_beam_track_shm()
-
-    def _close_beam_track_shm(self) -> None:
-        self._beam_track_shm.close()
-        self._beam_track_shm.unlink()
+        try:
+            self._subproc.terminate()
+        finally:
+            _cleanup_shm(self._beam_track_shm)
 
     def read_beam_track_element(self) -> int:
         """Read the active beam track element index from shared memory."""
+        if self._beam_track_shm.buf is None:
+            return -1
+
         return struct.unpack_from(_BEAM_TRACK_SHM_FMT, self._beam_track_shm.buf, 0)[0]
 
     def _tao_subprocess(self):

--- a/pytao/subproc.py
+++ b/pytao/subproc.py
@@ -6,11 +6,13 @@ import logging
 import os
 import pickle
 import queue
+import struct
 import subprocess
 import sys
 import tempfile
 import threading
 from collections.abc import Callable
+from multiprocessing.shared_memory import SharedMemory
 from typing import Any, Literal, Optional, Union, cast
 
 import numpy as np
@@ -31,7 +33,6 @@ Command = Literal[
     "cmd_real",
     "cmd_integer",
     "function",
-    "get_active_beam_track_element",
 ]
 SupportedKwarg = Union[float, int, str, bool, bytes, dict, list, tuple, set, np.ndarray]
 
@@ -129,6 +130,10 @@ def _get_result(
     raise RuntimeError(f"Unexpected pipe response: {value}")
 
 
+_BEAM_TRACK_SHM_FMT = "i"
+_BEAM_TRACK_SHM_SIZE = struct.calcsize(_BEAM_TRACK_SHM_FMT)
+
+
 class _TaoPipe:
     """
     Tao subprocess Pipe helper.
@@ -142,10 +147,13 @@ class _TaoPipe:
     _fifo: io.BufferedReader | None
     _subprocess_monitor_thread: threading.Thread | None
     _subprocess_env: dict[str, str]
+    _beam_track_shm: SharedMemory
 
     def __init__(self, env: dict[str, str]):
         self._init_queue = queue.Queue(maxsize=1)
         self._subprocess_env = env.copy()
+        self._beam_track_shm = SharedMemory(create=True, size=_BEAM_TRACK_SHM_SIZE)
+        struct.pack_into(_BEAM_TRACK_SHM_FMT, self._beam_track_shm.buf, 0, -1)
         self._subproc = self._init_subprocess()
 
     @property
@@ -160,10 +168,20 @@ class _TaoPipe:
             self.send_receive("quit", "", propagate_exceptions=False)
         except TaoDisconnectedError:
             pass
+        self._close_beam_track_shm()
 
     def close_forcefully(self) -> None:
         """Close the pipe."""
         self._subproc.terminate()
+        self._close_beam_track_shm()
+
+    def _close_beam_track_shm(self) -> None:
+        self._beam_track_shm.close()
+        self._beam_track_shm.unlink()
+
+    def read_beam_track_element(self) -> int:
+        """Read the active beam track element index from shared memory."""
+        return struct.unpack_from(_BEAM_TRACK_SHM_FMT, self._beam_track_shm.buf, 0)[0]
 
     def _tao_subprocess(self):
         """Subprocess monitor thread.  Cleans up after the subprocess ends."""
@@ -178,6 +196,7 @@ class _TaoPipe:
                         "-m",
                         "pytao.subproc_main",
                         fifo_path,
+                        self._beam_track_shm.name,
                     ],
                     stdin=subprocess.PIPE,
                     env=self._subprocess_env,
@@ -243,7 +262,7 @@ class _TaoPipe:
 
         Parameters
         ----------
-        cmd : one of {"init", "cmd", "cmd_real", "cmd_integer", "quit", "function", "get_active_beam_track_element"}
+        cmd : one of {"init", "cmd", "cmd_real", "cmd_integer", "quit", "function"}
             The command class to send.
         argument : str
             The argument to send to the command.
@@ -587,8 +606,6 @@ class SubprocessTao(Tao):
         )
 
     def get_active_beam_track_element(self) -> int:
-        """Get the active element index being tracked."""
-        return cast(
-            int,
-            self._send_command_through_pipe("get_active_beam_track_element", "", raises=True),
-        )
+        """Get the active element index being tracked via shared memory."""
+        assert self._subproc_pipe_ is not None
+        return self._subproc_pipe_.read_beam_track_element()

--- a/pytao/subproc_main.py
+++ b/pytao/subproc_main.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import logging
+import struct
 import sys
+import threading
 import traceback
+from multiprocessing.shared_memory import SharedMemory
 
 from .core import TaoCommandError
 from .subproc import (
@@ -11,6 +14,7 @@ from .subproc import (
     SubprocessResult,
     SubprocessSuccessResult,
     TaoDisconnectedError,
+    _BEAM_TRACK_SHM_FMT,
     read_pickled_data,
     write_pickled_data,
 )
@@ -20,10 +24,27 @@ from .util import import_by_name
 logger = logging.getLogger(__name__)
 
 
-def _tao_subprocess(output_fifo_filename: str) -> None:
+def _beam_track_writer(
+    tao: Tao,
+    shm: SharedMemory,
+    stop_event: threading.Event,
+    rate: float = 0.05,
+) -> None:
+    """Daemon thread that writes the active beam track element to shared memory."""
+    try:
+        while not stop_event.is_set():
+            idx = tao.so_lib.tao_c_get_beam_track_element()
+            struct.pack_into(_BEAM_TRACK_SHM_FMT, shm.buf, 0, idx)
+            stop_event.wait(rate)
+    finally:
+        shm.close()
+
+
+def _tao_subprocess(output_fifo_filename: str, beam_track_shm_name: str) -> None:
     logger.debug("Tao subprocess handler started")
 
     tao = None
+    beam_track_stop = threading.Event()
 
     def run_custom_function(message: SubprocessRequest, *_):
         func_name = message["arg"]
@@ -42,15 +63,17 @@ def _tao_subprocess(output_fifo_filename: str) -> None:
         if command == "init":
             if tao is None:
                 tao = Tao(arg)
+                shm = SharedMemory(name=beam_track_shm_name, create=False)
+                threading.Thread(
+                    daemon=True,
+                    target=_beam_track_writer,
+                    args=(tao, shm, beam_track_stop),
+                ).start()
                 return tao.init_output
             return tao.init(arg)
 
         if tao is None:
             raise TaoCommandError("Tao object not yet initialized")
-
-        if command == "get_active_beam_track_element":
-            tao._last_output = []
-            return tao.get_active_beam_track_element()
 
         if command == "function":
             tao._last_output = []
@@ -103,15 +126,16 @@ def _tao_subprocess(output_fifo_filename: str) -> None:
 if __name__ == "__main__":
     try:
         output_fifo_filename = sys.argv[1]
+        beam_track_shm_name = sys.argv[2]
     except (IndexError, ValueError):
         print(
-            f"Usage: {sys.executable} {__file__} (output_file_descriptor)",
+            f"Usage: {sys.executable} {__file__} (output_fifo) (beam_track_shm_name)",
             file=sys.stderr,
         )
         exit(1)
 
     try:
-        _tao_subprocess(output_fifo_filename)
+        _tao_subprocess(output_fifo_filename, beam_track_shm_name)
     except (TaoDisconnectedError, OSError):
         exit(1)
     except KeyboardInterrupt:

--- a/pytao/subproc_main.py
+++ b/pytao/subproc_main.py
@@ -5,6 +5,7 @@ import struct
 import sys
 import threading
 import traceback
+from multiprocessing import resource_tracker
 from multiprocessing.shared_memory import SharedMemory
 
 from .core import TaoCommandError
@@ -64,6 +65,8 @@ def _tao_subprocess(output_fifo_filename: str, beam_track_shm_name: str) -> None
             if tao is None:
                 tao = Tao(arg)
                 shm = SharedMemory(name=beam_track_shm_name, create=False)
+                # Parent owns the shm lifecycle
+                resource_tracker.unregister(f"/{shm.name}", "shared_memory")
                 threading.Thread(
                     daemon=True,
                     target=_beam_track_writer,

--- a/pytao/subproc_main.py
+++ b/pytao/subproc_main.py
@@ -5,17 +5,16 @@ import struct
 import sys
 import threading
 import traceback
-from multiprocessing import resource_tracker
-from multiprocessing.shared_memory import SharedMemory
 
+from ._shmem_compat import SharedMemory
 from .core import TaoCommandError
 from .subproc import (
+    _BEAM_TRACK_SHM_FMT,
     SubprocessErrorResult,
     SubprocessRequest,
     SubprocessResult,
     SubprocessSuccessResult,
     TaoDisconnectedError,
-    _BEAM_TRACK_SHM_FMT,
     read_pickled_data,
     write_pickled_data,
 )
@@ -64,9 +63,7 @@ def _tao_subprocess(output_fifo_filename: str, beam_track_shm_name: str) -> None
         if command == "init":
             if tao is None:
                 tao = Tao(arg)
-                shm = SharedMemory(name=beam_track_shm_name, create=False)
-                # Parent owns the shm lifecycle
-                resource_tracker.unregister(f"/{shm.name}", "shared_memory")
+                shm = SharedMemory(name=beam_track_shm_name, create=False, track=False)
                 threading.Thread(
                     daemon=True,
                     target=_beam_track_writer,

--- a/pytao/tests/test_pbar.py
+++ b/pytao/tests/test_pbar.py
@@ -1,6 +1,9 @@
 import numpy as np
 
-from .. import AnyTao
+import threading
+import time
+
+from .. import AnyTao, SubprocessTao
 from .test_interface_commands import new_tao
 
 
@@ -47,6 +50,38 @@ def test_cli_progress_bar(tao_cls: type[AnyTao]):
         set_gaussian(tao, n_particle=1)
         tao.track_beam(use_progress_bar=False)
         tao.track_beam(use_progress_bar=True)
+
+
+def _sleep_cmd(tao: SubprocessTao):
+    time.sleep(1)
+
+
+def test_shm_read_during_tracking():
+    with new_tao(
+        SubprocessTao,
+        init_file="$ACC_ROOT_DIR/bmad-doc/tao_examples/optics_matching/tao.init",
+    ) as tao:
+        observed = []
+        start = threading.Event()
+        stop = threading.Event()
+
+        def poll_active_element():
+            start.wait()
+            while not stop.is_set():
+                observed.append(tao.get_active_beam_track_element())
+                time.sleep(0.1)
+
+        poller = threading.Thread(target=poll_active_element, daemon=True)
+        poller.start()
+        try:
+            start.set()
+            # tao.track_beam(use_progress_bar=False)
+            tao.subprocess_call(_sleep_cmd)
+        finally:
+            stop.set()
+            poller.join(timeout=2)
+
+        assert len(observed) > 5, "Should observe at least 5 element calls during the sleep"
 
 
 def test_cli_progress_bar_track_start(tao_cls: type[AnyTao]):


### PR DESCRIPTION
## Changes

This adds an internal shared memory side channel to the subprocess Tao pipe scheme, allowing for querying the active beam tracking element while long-running commands are happening. Without this, the commands just get queued and you see 0% -> 100% with the track_beam progress bar - if you're lucky. If you're unlucky, it deadlocks.

There's also a bit of Python < 3.13 tweaks added based on https://github.com/python/cpython/issues/82300#issuecomment-2169035092 - I'll let the commit message [here](https://github.com/bmad-sim/pytao/pull/154/commits/7c9f7515a3faccfaf2011a1307145ed9ac2ac99a) speak for itself.

### Notes

To test this, use an init file with beam tracking already configured. The `pytao` CLI defaults to `SubprocessTao` so the following will suffice:

```
pytao -init your-init-file.init
tao.track_beam()
```

### Implementation

The polling in the subprocess happens regardless of whether tracking or any command is taking place. Though it happens at a decent rate, it's rather lightweight. I think any additional machinery would complicate/slow things down further.