### PR TITLE
PERF: faster ndarray restore from msgpack + helpers for dealing with raw data

### DIFF
--- a/pytao/model/base.py
+++ b/pytao/model/base.py
@@ -756,15 +756,34 @@ def _msgpack_default(obj: Any) -> Any:
 
 
 def _msgpack_restore_ndarrays(obj: Any) -> Any:
-    """Restore numpy arrays from the ``__ndarray__`` marker dicts."""
-    # NOTE: this is borrowed from LUME-Genesis archiving, and ideally should be
-    # kept in sync
+    """Restore numpy arrays from ``__ndarray__`` marker dicts, in-place.
+
+    Walks the deserialized msgpack structure and replaces marker dicts
+    with actual numpy arrays.  Modifies containers in-place to avoid
+    rebuilding the entire tree (which is expensive for large lattice
+    dumps).
+    """
     if isinstance(obj, dict):
-        if _MSGPACK_NDARRAY_MARKER in obj:
-            return np.frombuffer(obj[_MSGPACK_NDARRAY_MARKER], dtype=obj["dtype"]).reshape(
-                obj["shape"]
-            )
-        return {key: _msgpack_restore_ndarrays(value) for key, value in obj.items()}
-    if isinstance(obj, list):
-        return [_msgpack_restore_ndarrays(item) for item in obj]
+        for key in obj:
+            value = obj[key]
+            if isinstance(value, dict):
+                if _MSGPACK_NDARRAY_MARKER in value:
+                    obj[key] = np.frombuffer(
+                        value[_MSGPACK_NDARRAY_MARKER], dtype=value["dtype"]
+                    ).reshape(value["shape"])
+                else:
+                    _msgpack_restore_ndarrays(value)
+            elif isinstance(value, list):
+                _msgpack_restore_ndarrays(value)
+    elif isinstance(obj, list):
+        for i, item in enumerate(obj):
+            if isinstance(item, dict):
+                if _MSGPACK_NDARRAY_MARKER in item:
+                    obj[i] = np.frombuffer(
+                        item[_MSGPACK_NDARRAY_MARKER], dtype=item["dtype"]
+                    ).reshape(item["shape"])
+                else:
+                    _msgpack_restore_ndarrays(item)
+            elif isinstance(item, list):
+                _msgpack_restore_ndarrays(item)
     return obj

--- a/pytao/model/base.py
+++ b/pytao/model/base.py
@@ -562,6 +562,7 @@ def load_model_data(
     filename: str | pathlib.Path,
     *,
     format: ArchiveFormat | None = None,
+    raw: bool = False,
 ):
     """
     Read the raw model data from a file in JSON, YAML, or msgpack format.
@@ -573,6 +574,11 @@ def load_model_data(
         The file format is determined by the extension.
     format : ArchiveFormat or None, optional
         File format.  If not specified, determined by file extension.
+    raw : bool, optional
+        If False, any data not stored in its native format may be returned
+        as-is from the source format.  Specifically, when using the MessagePack
+        format, NDArray instances may be returned as an encoded dictionary.
+        If True, all conversions will be applied recursively to the data.
     """
     fname = pathlib.Path(filename)
 
@@ -587,7 +593,9 @@ def load_model_data(
         import ormsgpack
 
         data = ormsgpack.unpackb(fname.read_bytes(), option=ormsgpack.OPT_NON_STR_KEYS)
-        return _msgpack_restore_ndarrays(data)
+        if not raw:
+            _msgpack_restore_ndarrays(data)
+        return data
     elif format == "json.gz":
         with gzip.open(fname, "rb") as fp:
             return orjson.loads(fp.read())
@@ -615,7 +623,7 @@ def load_model(
     format : ArchiveFormat or None, optional
         File format.  If not specified, determined by file extension.
     """
-    data = load_model_data(filename, format=format)
+    data = load_model_data(filename, format=format, raw=True)
     return cls.model_validate(data)
 
 

--- a/pytao/model/ele/ele.py
+++ b/pytao/model/ele/ele.py
@@ -15,7 +15,7 @@ from ...errors import TaoCommandError
 from ...util.parsers import Attr, parse_tao_python_data_with_units
 from .. import _generated as tao_classes
 from ..base import ArchiveFormat, TaoBaseModel, TaoModel
-from ..types import NDArray
+from ..types import NDArray, _PydanticNDArray
 from .comb import Comb
 from .time_stats import _pytao_stats
 
@@ -2486,3 +2486,38 @@ class Lattice(TaoBaseModel):
         lat = super().from_file(filename, format=format)
         lat.filename = pathlib.Path(filename)
         return lat
+
+
+def restore_raw_element_ndarrays(ele: dict) -> None:
+    """
+    In-place restore ndarrays given a raw element dict.
+
+    Notes
+    -----
+    You will not typically need this routine. Normally, you will want to just use
+    `Lattice.from_file` which handles all of the validation and conversion
+    under the hood.
+
+    If you are after raw performance of loading the state of a lattice into memory
+    and you don't care about using the Element classes themselves, this function
+    may be of use to you.  This will reinflate `ndarray` instances from the raw
+    dictionaries so that you may use them as normal, with significantly less overhead
+    than the generic version.
+    """
+    mat6 = ele.get("mat6")
+    if mat6:
+        for key in ("vec0", "mat6"):
+            val = mat6.get(key)
+            if val is not None:
+                mat6[key] = _PydanticNDArray._pydantic_validate(val, None)
+
+    floor = ele.get("floor")
+    if floor:
+        for pos_data in (floor.get("beginning"), floor.get("center"), floor.get("end")):
+            if not pos_data:
+                continue
+            for ref_data in (pos_data.get("actual"), pos_data.get("reference")):
+                if ref_data and "wmat" in ref_data:
+                    ref_data["wmat"] = _PydanticNDArray._pydantic_validate(
+                        ref_data["wmat"], None
+                    )

--- a/pytao/model/types.py
+++ b/pytao/model/types.py
@@ -162,14 +162,21 @@ class _PydanticNDArray:
             ),
         )
 
+    #: Marker key used by msgpack serialization to identify ndarray dicts.
+    _MSGPACK_MARKER: str = "__ndarray__"
+
     @classmethod
     def _pydantic_validate(
         cls,
         value: Any | np.ndarray | Sequence | dict,
-        info: pydantic.ValidationInfo,
+        info: pydantic.ValidationInfo | None,
     ) -> np.ndarray:
         if isinstance(value, np.ndarray):
             return value
+        if isinstance(value, dict) and cls._MSGPACK_MARKER in value:
+            return np.frombuffer(value[cls._MSGPACK_MARKER], dtype=value["dtype"]).reshape(
+                value["shape"]
+            )
         if isinstance(value, Sequence):
             return np.asarray(value)
         raise ValueError(f"No conversion from {value!r} to numpy ndarray")

--- a/pytao/tests/ele/test_ele.py
+++ b/pytao/tests/ele/test_ele.py
@@ -9,9 +9,11 @@ import pytest
 
 import pytao
 from pytao import SubprocessTao
-from pytao.model.base import format_from_filename
+from pytao.model.base import TaoBaseModel, format_from_filename
 from pytao.model.ele import Element, Lattice
+from pytao.model.ele.ele import restore_raw_element_ndarrays
 from pytao.model.ele.time_stats import _PytaoStatistics, get_pytao_statistics
+from pytao.model.types import NDArray
 
 from ..conftest import no_pytao_debug_logging, timed_section
 
@@ -507,3 +509,130 @@ def test_lr_mode_table():
 
         np.testing.assert_allclose(float(lr_mode[0][4]), 0.7)
         assert [row[4] for row in lr_mode[1:]] == ["none", "none"]
+
+
+def _make_ndarray_dict(arr: np.ndarray) -> dict:
+    arr = np.ascontiguousarray(arr)
+    return {
+        "__ndarray__": arr.tobytes(),
+        "dtype": str(arr.dtype),
+        "shape": list(arr.shape),
+    }
+
+
+def test_raw_mat6_msgpack():
+    vec0 = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    mat6 = np.eye(6)
+    ele = {
+        "mat6": {
+            "vec0": _make_ndarray_dict(vec0),
+            "mat6": _make_ndarray_dict(mat6),
+        }
+    }
+    restore_raw_element_ndarrays(ele)
+    assert isinstance(ele["mat6"]["vec0"], np.ndarray)
+    assert isinstance(ele["mat6"]["mat6"], np.ndarray)
+    np.testing.assert_array_equal(ele["mat6"]["vec0"], vec0)
+    np.testing.assert_array_equal(ele["mat6"]["mat6"], mat6)
+
+
+def test_raw_mat6_lists():
+    ele = {
+        "mat6": {
+            "vec0": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            "mat6": [[1.0, 0.0], [0.0, 1.0]],
+        }
+    }
+    restore_raw_element_ndarrays(ele)
+    assert isinstance(ele["mat6"]["vec0"], np.ndarray)
+    assert isinstance(ele["mat6"]["mat6"], np.ndarray)
+    np.testing.assert_array_equal(ele["mat6"]["vec0"], [1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    np.testing.assert_array_equal(ele["mat6"]["mat6"], [[1.0, 0.0], [0.0, 1.0]])
+
+
+def test_raw_floor_wmat_msgpack():
+    wmat = np.eye(3)
+    wmat_raw = _make_ndarray_dict(wmat)
+    ele = {
+        "floor": {
+            "beginning": {
+                "actual": {"wmat": dict(wmat_raw)},
+                "reference": {"wmat": dict(wmat_raw)},
+            },
+            "center": {
+                "actual": {"wmat": dict(wmat_raw)},
+            },
+            "end": {
+                "reference": {"wmat": dict(wmat_raw)},
+            },
+        }
+    }
+    restore_raw_element_ndarrays(ele)
+    for pos in ("beginning", "center", "end"):
+        for ref in ("actual", "reference"):
+            val = ele["floor"][pos].get(ref, {}).get("wmat")
+            if val is not None:
+                assert isinstance(val, np.ndarray)
+                np.testing.assert_array_equal(val, wmat)
+
+
+def test_raw_mat6_and_floor():
+    vec0 = np.array([0.0, 0.0])
+    mat = np.array([[1.0]])
+    wmat = np.eye(2)
+    ele = {
+        "mat6": {
+            "vec0": _make_ndarray_dict(vec0),
+            "mat6": _make_ndarray_dict(mat),
+        },
+        "floor": {
+            "beginning": {
+                "actual": {"wmat": _make_ndarray_dict(wmat)},
+            },
+        },
+    }
+    restore_raw_element_ndarrays(ele)
+    assert isinstance(ele["mat6"]["vec0"], np.ndarray)
+    assert isinstance(ele["mat6"]["mat6"], np.ndarray)
+    assert isinstance(ele["floor"]["beginning"]["actual"]["wmat"], np.ndarray)
+
+
+def test_raw_empty_dict():
+    ele = {}
+    restore_raw_element_ndarrays(ele)
+    assert ele == {}
+
+
+def test_raw_no_mat6_no_floor():
+    ele = {"name": "Q1", "head": {"key": "quadrupole"}}
+    restore_raw_element_ndarrays(ele)
+    assert ele == {"name": "Q1", "head": {"key": "quadrupole"}}
+
+
+def test_raw_already_ndarray():
+    vec = np.array([1.0, 2.0])
+    ele = {"mat6": {"vec0": vec}}
+    restore_raw_element_ndarrays(ele)
+    assert ele["mat6"]["vec0"] is vec
+
+
+class ArrHolder(TaoBaseModel):
+    arr: NDArray
+
+
+def test_ndarray_validate():
+    arr = np.asarray([1, 2, 3])
+    holder = ArrHolder(arr=arr)
+    holder.model_dump()
+
+    d = {"arr": _make_ndarray_dict(arr)}
+    restored = ArrHolder.model_validate(d)
+    assert holder == restored
+
+    d = {"arr": arr}
+    restored = ArrHolder.model_validate(d)
+    assert holder == restored
+
+    d = {"arr": arr.tolist()}
+    restored = ArrHolder.model_validate(d)
+    assert holder == restored


### PR DESCRIPTION
## Background

Focusing on faster `np.ndarray` restoring from archived lattice data in MessagePack format files.

## Changes

* The `_PydanticNDArray` class that handles (de)serialization of `np.ndarray` directly can now take the dictified msgpack array data, avoiding separate full tree traversal
* Separately, when you still need the model data just as a dictionary: a bit faster array restoration for large lattices by working in-place
* Finally, a helper for a "raw" mode for just getting back element dict data (or other model data). This is faster than a full pydantic validation, and also faster than the full generic tree traversal (even post-refactor)

## Benchmarks

Using `$ACC_ROOT_DIR/bmad-doc/tao_examples/cbeta_ffag/tao.init` which has 874 tracking elements:

Master branch:
```
  Lattice.write (save)                      median=   250.1 ms  mean=   236.8 ms  std=   33.6 ms  min=   170.1 ms  (n=10)
  Lattice.from_file (full validation)       median=   586.8 ms  mean=   592.8 ms  std=   44.5 ms  min=   543.1 ms  (n=10)
  load_model_data (ndarray restore)         median=   267.1 ms  mean=   268.6 ms  std=    3.8 ms  min=   264.0 ms  (n=10)
```

This PR:

```
  Lattice.write (save)                      median=   241.3 ms  mean=   236.3 ms  std=   22.2 ms  min=   171.5 ms  (n=10)
  Lattice.from_file (full validation)       median=   461.1 ms  mean=   438.8 ms  std=   45.6 ms  min=   346.4 ms  (n=10)
  load_model_data (ndarray restore)         median=   124.8 ms  mean=   124.8 ms  std=    1.4 ms  min=   122.7 ms  (n=10)
  load_model_data raw (no restore)          median=    62.9 ms  mean=    62.4 ms  std=    1.0 ms  min=    60.3 ms  (n=10)
  load raw + restore_raw_element_ndarrays   median=    76.4 ms  mean=    75.3 ms  std=    6.4 ms  min=    60.0 ms  (n=10)
```

**Note**: Typically, users will only use `Lattice.write` and `Lattice.from_file` (directly or indirectly).

* The write speed here, as expected, is unchanged.
* `Lattice.from_file` is about 1.65x faster on average with this PR.
* Advanced users like myself who may be interested in just loading raw element data as fast as possible - skipping the helpful `Lattice` and `Element` instances, working directly with dictionaries - can use the `load raw + restore_ndarrays` 3.6x faster.