### PR TITLE
FIX: equality checks for TaoModel

### DIFF
--- a/pytao/model/base.py
+++ b/pytao/model/base.py
@@ -95,12 +95,13 @@ def _check_equality(obj1: Any, obj2: Any) -> bool:
         )
 
     if isinstance(obj1, np.ndarray):
-        if not obj1.shape and not obj2.shape:
-            return True
-        return np.allclose(obj1, obj2)
+        if not obj1.shape:
+            # Empty arrays
+            return bool(not obj2.shape)
+        return np.array_equal(obj1, obj2)
 
     if isinstance(obj1, float):
-        return np.allclose(obj1, obj2)
+        return obj1 == obj2
 
     return bool(obj1 == obj2)
 


### PR DESCRIPTION
## Background

Previously, there was some concern about our serialization methods being somewhat lossy (specifically JSON/YAML), which led to `TaoModel.__eq__` comparisons deferring to `np.allclose` (which has defaults `rtol=1e-05` and `atol=1e-08`). This seemed "good enough" on the surface. 

However, in the current master branch, `BeamInit(bunch_charge=1e-10)  == BeamInit()` would be `True` due to these tolerances. This is absolutely not a good thing, as PyTao would then not update `bunch_charge` setting in Tao thinking it's too close to the default. 

### Serialization methods

Considering the serialization/deserialization methods:

* MessagePack via `ormsgpack`: this is a binary format and stored exactly
* Pickle: also exact binary data
* HDF5: also exact binary data. We don't use it in PyTao, but this equality check came from LUME-Genesis. I'll be fixing this upstream shortly.
* JSON via `orjson`: _orjson serializes and deserializes double precision floats with no loss of precision and consistent rounding._ ([ref](https://github.com/ijl/orjson#float))
* YAML: with a bit of digging, this uses [repr](https://github.com/yaml/pyyaml/blob/d51d8a138f7230834fc6e95635ff09ebd329185f/lib/yaml/representer.py#L179) under the hood. Per the Python [docs](https://docs.python.org/3/tutorial/floatingpoint.html): _Since all of these decimal values share the same approximation, any one of them could be displayed while still preserving the invariant `eval(repr(x)) == x`._ Well, that's good enough I'd say.

The test suite validates JSON and MessagePack. YAML is too slow to write an entire lattice, so it's currently skipped in the test suite.

Based on the above, I think this is good to go. The original concerns were unfounded - and I should have revisited this sooner rather than later.

## Changes

This reverts the comparison to actual equality (`np.array_equal` / `==` for floats)

