### PR TITLE
FIX: ensure ParticleGroup serializes to json as well

### DIFF
--- a/pytao/model/types.py
+++ b/pytao/model/types.py
@@ -73,8 +73,12 @@ class _PydanticParticleGroup:
     def _from_dict(data: ParticleData) -> ParticleGroup:
         return ParticleGroup(data=data)
 
-    def _as_dict(self) -> ParticleData:
-        return self.data
+    @staticmethod
+    def _as_dict(obj) -> dict:
+        return {
+            key: value.tolist() if isinstance(value, np.ndarray) else value
+            for key, value in obj.data.items()
+        }
 
     @classmethod
     def __get_pydantic_core_schema__(
@@ -111,11 +115,12 @@ class _PydanticPmdUnit:
             dim = tuple(dim)
         return pmd_unit(**dct, unitDimension=dim)
 
-    def _as_dict(self) -> dict[str, Any]:
+    @staticmethod
+    def _as_dict(obj: pmd_unit) -> dict[str, Any]:
         return {
-            "unitSI": self.unitSI,
-            "unitSymbol": self.unitSymbol,
-            "unitDimension": tuple(self.unitDimension),
+            "unitSI": obj.unitSI,
+            "unitSymbol": obj.unitSymbol,
+            "unitDimension": tuple(obj.unitDimension),
         }
 
     @classmethod

--- a/pytao/tests/ele/test_model_classes.py
+++ b/pytao/tests/ele/test_model_classes.py
@@ -1,14 +1,22 @@
 from __future__ import annotations
-import pathlib
 
+import operator
+import pathlib
+from typing import Generator
+
+import numpy as np
 import pytest
+from beamphysics import single_particle
+from beamphysics.units import pmd_unit
+from pydantic import TypeAdapter
 
 from pytao import SubprocessTao, TaoCommandError
 from pytao.model import Beam, BeamInit, SpaceChargeCom, TaoConfig, TaoGlobal
+from pytao.model.types import NDArray, PydanticParticleGroup, PydanticPmdUnit
 
 
 @pytest.fixture(scope="module")
-def tao() -> SubprocessTao:
+def tao() -> Generator[SubprocessTao, None, None]:
     with SubprocessTao(
         init_file="$ACC_ROOT_DIR/regression_tests/pipe_test/tao.init_wall3d", noplot=True
     ) as tao:
@@ -151,3 +159,32 @@ def test_global_nthreads(tao: SubprocessTao) -> None:
         raise
 
     assert TaoGlobal.from_tao(tao) == glob
+
+
+@pytest.mark.parametrize(
+    "type_annotation, obj, comparator",
+    [
+        pytest.param(
+            PydanticPmdUnit,
+            pmd_unit.from_symbol("m"),
+            operator.eq,
+            id="pmd_unit",
+        ),
+        pytest.param(
+            PydanticParticleGroup,
+            single_particle(),
+            operator.eq,
+            id="particlegroup",
+        ),
+        pytest.param(
+            NDArray,
+            np.array([[1, 2, 3], [4, 5, 6]]),
+            np.array_equal,
+            id="ndarray",
+        ),
+    ],
+)
+def test_json_serialization(type_annotation, obj, comparator):
+    adapter = TypeAdapter(type_annotation)
+    assert comparator(adapter.validate_python(adapter.dump_python(obj)), obj)
+    assert comparator(adapter.validate_json(adapter.dump_json(obj)), obj)


### PR DESCRIPTION
Previously untested (oops), `PydanticParticleGroup` was not dumping to JSON properly. This fixes and adds a test for it.