### PR TITLE
Read-only optimization introspection (`pytao.optimize`)

### DIFF
--- a/docs/api/optimize.md
+++ b/docs/api/optimize.md
@@ -1,0 +1,7 @@
+# `pytao.optimize`
+
+::: pytao.optimize.TaoOptimizationProblem
+
+::: pytao.optimize.VariableInfo
+
+::: pytao.optimize.DatumInfo

--- a/docs/optimize.md
+++ b/docs/optimize.md
@@ -63,8 +63,27 @@ problem.variables           # list[VariableInfo]
 problem.datums              # list[DatumInfo]
 ```
 
-`VariableInfo` and `DatumInfo` are frozen dataclasses — safe to pass around,
-store in tables, or serialise without worrying about accidental mutation.
+`problem.variables` and `problem.datums` are tuples of frozen dataclasses, so
+the snapshot is immutable — no accidental `append`/`pop` can desynchronise
+it from the `x0`/`bounds`/`weights` arrays.
+
+## Multi-universe sessions
+
+By default, `TaoOptimizationProblem` reads Tao's live
+`s%global%default_universe` and snapshots against it — the same behaviour as
+Tao's own `pipe data_*` commands. That means in a single-universe session
+you don't need to think about universes at all, and in a multi-universe
+session the problem follows whatever universe was active when you built it.
+
+To target a specific universe explicitly:
+
+```python
+problem = TaoOptimizationProblem(tao, universe=2)
+```
+
+Useful when you want to inspect several universes side-by-side, or when a
+routine mutates Tao's default universe and you want the snapshot pinned to
+a known one.
 
 ## What's next
 
@@ -82,4 +101,6 @@ Each will ship as its own PR so reviewers can evaluate them independently.
 ## See also
 
 - [API reference](api/optimize.md)
-- Tao manual, chapter on optimization
+- [Tao manual — optimization chapter][tao-opt]
+
+[tao-opt]: https://www.classe.cornell.edu/bmad/tao_manual.pdf

--- a/docs/optimize.md
+++ b/docs/optimize.md
@@ -1,0 +1,85 @@
+# Inspecting a Tao optimization setup from Python
+
+The `pytao.optimize` subpackage exposes the variables, datums, bounds, and
+weights that Tao itself would use for optimization as structured Python
+objects. That makes it straightforward to inspect a `tao.init` configuration
+interactively, or to plug Tao into external optimizer libraries in follow-up
+work.
+
+This first release is intentionally read-only. It does not mutate Tao's
+state or evaluate the merit function. Both of those capabilities will arrive
+in subsequent releases; the data model here is the foundation they'll build on.
+
+## Quickstart
+
+```python
+from pytao import Tao
+from pytao.optimize import TaoOptimizationProblem
+
+tao = Tao(init_file="tao.init", noplot=True)
+problem = TaoOptimizationProblem(tao)
+
+print(f"{problem.n_var} active variables, {problem.n_data} active datums")
+
+for v in problem.variables:
+    print(f"  {v.name} ({v.ele_name}.{v.attrib_name}): "
+          f"initial={v.initial_value:.3g}  "
+          f"bounds=[{v.low_lim:.3g}, {v.high_lim:.3g}]")
+
+for d in problem.datums:
+    print(f"  {d.name} ({d.data_type}, {d.merit_type}): "
+          f"meas={d.meas_value:.3g}  weight={d.weight:.3g}")
+```
+
+## What gets picked up from the init file
+
+`TaoOptimizationProblem` reads the live Tao state and collects:
+
+- **Variables** with `useit_opt = True` (i.e., `good_user & good_opt`).
+  Bounds come from `low_lim` / `high_lim`; values at or past ±10²⁰ are
+  treated as "no limit" and translated to `±inf`. Steps, weights, merit
+  types, and element/attribute names are preserved.
+- **Datums** with `useit_opt = True`, with their `meas_value`, `weight`,
+  and `merit_type`. Target-style datums (`merit_type = 'target'`) will
+  become standard residuals when the evaluation layer lands; limit-style
+  datums (`'min'`, `'max'`, `'abs_min'`, `'abs_max'`) are preserved so
+  downstream code can reproduce Tao's soft-constraint semantics.
+
+Negative weights are rejected at construction time — they're nonsensical in
+Tao's merit function (`sum(w * delta**2)` requires `w >= 0`) and catching
+them at the boundary avoids silent NaN production downstream.
+
+## Properties you can read
+
+```python
+problem.n_var               # number of active optimization variables
+problem.n_data              # number of active datums
+problem.x0                  # initial variable vector (np.ndarray)
+problem.variable_names      # ["v1[1]", "v1[2]", ...]
+problem.bounds              # [(low, high), ...] — ±inf allowed
+problem.bounds_array        # (lb, ub) ndarrays (scipy.least_squares shape)
+problem.weights             # per-datum merit weights (np.ndarray)
+problem.variables           # list[VariableInfo]
+problem.datums              # list[DatumInfo]
+```
+
+`VariableInfo` and `DatumInfo` are frozen dataclasses — safe to pass around,
+store in tables, or serialise without worrying about accidental mutation.
+
+## What's next
+
+Follow-up releases will layer on:
+
+- `set_variables(x)` and `evaluate_merit(x)` for round-tripping variable
+  updates through Tao.
+- `evaluate_residuals(x)` and `jacobian(x)` mirroring Tao's merit function
+  structure (including limit-type variable contributions).
+- Adapters such as `run_scipy_minimize` and `run_scipy_least_squares` that
+  let you drive Tao optimization from the SciPy ecosystem.
+
+Each will ship as its own PR so reviewers can evaluate them independently.
+
+## See also
+
+- [API reference](api/optimize.md)
+- Tao manual, chapter on optimization

--- a/docs/optimize.md
+++ b/docs/optimize.md
@@ -17,7 +17,7 @@ from pytao import Tao
 from pytao.optimize import TaoOptimizationProblem
 
 tao = Tao(init_file="tao.init", noplot=True)
-problem = TaoOptimizationProblem(tao)
+problem = TaoOptimizationProblem.from_tao(tao)
 
 print(f"{problem.n_var} active variables, {problem.n_data} active datums")
 
@@ -63,9 +63,12 @@ problem.variables           # list[VariableInfo]
 problem.datums              # list[DatumInfo]
 ```
 
-`problem.variables` and `problem.datums` are tuples of frozen dataclasses, so
-the snapshot is immutable — no accidental `append`/`pop` can desynchronise
-it from the `x0`/`bounds`/`weights` arrays.
+`problem.variables` and `problem.datums` are tuples of frozen Pydantic
+models (built on pytao's `TaoBaseModel`), so the snapshot is immutable —
+no accidental `append`/`pop` can desynchronise it from the
+`x0`/`bounds`/`weights` arrays. You also get JSON / YAML / msgpack
+round-tripping for free via the inherited `.write()` / `.from_file()`
+helpers.
 
 ## Multi-universe sessions
 
@@ -78,7 +81,7 @@ session the problem follows whatever universe was active when you built it.
 To target a specific universe explicitly:
 
 ```python
-problem = TaoOptimizationProblem(tao, universe=2)
+problem = TaoOptimizationProblem.from_tao(tao, universe=2)
 ```
 
 Useful when you want to inspect several universes side-by-side, or when a

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -13,7 +13,7 @@ from pytao import Tao
 from pytao.optimize import TaoOptimizationProblem
 
 tao = Tao(init_file="tao.init", noplot=True)
-problem = TaoOptimizationProblem(tao)
+problem = TaoOptimizationProblem.from_tao(tao)
 
 problem.n_var           # number of active optimization variables
 problem.n_data          # number of active datums
@@ -32,12 +32,14 @@ Highlights:
   optimizer libraries see standard unbounded-side semantics.
 - Rejects negative weights at construction — catches a class of user errors
   at the boundary rather than silently producing NaNs later.
-- Multi-universe aware: with no argument, `TaoOptimizationProblem` reads
-  Tao's live `s%global%default_universe`; pass `universe=N` to pin the
-  snapshot to a specific universe.
-- `problem.variables` and `problem.datums` are immutable tuples of frozen
-  dataclasses, so the snapshot cannot drift out of sync with `x0`,
-  `bounds`, and `weights`.
+- Multi-universe aware: with no argument, `from_tao` reads Tao's live
+  `s%global%default_universe`; pass `universe=N` to pin the snapshot to
+  a specific universe.
+- Built on `TaoBaseModel` (Pydantic) — `problem.variables` and
+  `problem.datums` are immutable tuples of frozen models, so the
+  snapshot cannot drift out of sync with `x0`, `bounds`, and `weights`.
+  JSON / YAML / msgpack round-tripping comes for free via the standard
+  `.write()` / `.from_file()` helpers.
 
 This is the first slice of a larger Python-driven optimization workflow.
 Follow-up releases will add merit evaluation, Jacobian access, and SciPy

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,3 +1,45 @@
+# Unreleased
+
+## New Features
+
+### Read-only optimization introspection (`pytao.optimize`)
+
+A new subpackage that reads a live `Tao` instance and reports its
+optimization setup as structured Python objects — the variables and datums
+Tao would use for optimization, plus their bounds, weights, and merit types.
+
+```python
+from pytao import Tao
+from pytao.optimize import TaoOptimizationProblem
+
+tao = Tao(init_file="tao.init", noplot=True)
+problem = TaoOptimizationProblem(tao)
+
+problem.n_var           # number of active optimization variables
+problem.n_data          # number of active datums
+problem.x0              # initial variable vector
+problem.bounds          # list of (low, high) tuples; ±inf allowed
+problem.weights         # per-datum merit weights
+problem.variables       # list[VariableInfo]
+problem.datums          # list[DatumInfo]
+```
+
+Highlights:
+
+- Filters to `useit_opt = True` entries, i.e. what Tao itself would pass to
+  its internal optimizers.
+- Translates Tao's ±1e30 "no limit" sentinels to ±inf so downstream
+  optimizer libraries see standard unbounded-side semantics.
+- Rejects negative weights at construction — catches a class of user errors
+  at the boundary rather than silently producing NaNs later.
+- `VariableInfo` and `DatumInfo` are frozen dataclasses suitable for tables,
+  serialisation, or passing between modules.
+
+This is the first slice of a larger Python-driven optimization workflow.
+Follow-up releases will add merit evaluation, Jacobian access, and SciPy
+adapters (`run_scipy_minimize`, `run_scipy_least_squares`). See the
+[optimization guide](optimize.md) for a walkthrough.
+
 # v1.0.0
 
 ## New Features

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -32,8 +32,12 @@ Highlights:
   optimizer libraries see standard unbounded-side semantics.
 - Rejects negative weights at construction — catches a class of user errors
   at the boundary rather than silently producing NaNs later.
-- `VariableInfo` and `DatumInfo` are frozen dataclasses suitable for tables,
-  serialisation, or passing between modules.
+- Multi-universe aware: with no argument, `TaoOptimizationProblem` reads
+  Tao's live `s%global%default_universe`; pass `universe=N` to pin the
+  snapshot to a specific universe.
+- `problem.variables` and `problem.datums` are immutable tuples of frozen
+  dataclasses, so the snapshot cannot drift out of sync with `x0`,
+  `bounds`, and `weights`.
 
 This is the first slice of a larger Python-driven optimization workflow.
 Follow-up releases will add merit evaluation, Jacobian access, and SciPy

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ nav:
   - Installation: installation.md
 
   - Usage: usage.md
+  - Optimization: optimize.md
   - Releases: release_notes.md
 
   - Examples:
@@ -35,6 +36,7 @@ nav:
       - Plotting: api/plot.md
       - Matplotlib: api/plot-mpl.md
       - Bokeh: api/plot-bokeh.md
+      - Optimization: api/optimize.md
 
 theme:
   icon:

--- a/pytao/optimize/__init__.py
+++ b/pytao/optimize/__init__.py
@@ -6,10 +6,13 @@ itself would use for optimization, as structured Python objects. That makes it
 straightforward to feed them into external optimizer libraries in follow-up
 work — but nothing in this first slice mutates Tao state or evaluates merit.
 
-Start with :class:`TaoOptimizationProblem`: construct one from a live
-:class:`~pytao.Tao`, then inspect :attr:`~TaoOptimizationProblem.variables`,
+Start with :meth:`TaoOptimizationProblem.from_tao`: pass a live
+:class:`~pytao.Tao` and inspect :attr:`~TaoOptimizationProblem.variables`,
 :attr:`~TaoOptimizationProblem.datums`, :attr:`~TaoOptimizationProblem.x0`,
-:attr:`~TaoOptimizationProblem.bounds`, and :attr:`~TaoOptimizationProblem.weights`.
+:attr:`~TaoOptimizationProblem.bounds`, and
+:attr:`~TaoOptimizationProblem.weights`. The returned object is a
+:class:`~pytao.model.base.TaoBaseModel` snapshot — immutable, serialisable
+via the usual ``.write()`` / ``.from_file()`` helpers.
 """
 
 from __future__ import annotations

--- a/pytao/optimize/__init__.py
+++ b/pytao/optimize/__init__.py
@@ -1,0 +1,27 @@
+"""
+Inspect a live Tao instance's optimization setup from Python.
+
+This subpackage exposes the variables, datums, bounds, and weights that Tao
+itself would use for optimization, as structured Python objects. That makes it
+straightforward to feed them into external optimizer libraries in follow-up
+work — but nothing in this first slice mutates Tao state or evaluates merit.
+
+Start with :class:`TaoOptimizationProblem`: construct one from a live
+:class:`~pytao.Tao`, then inspect :attr:`~TaoOptimizationProblem.variables`,
+:attr:`~TaoOptimizationProblem.datums`, :attr:`~TaoOptimizationProblem.x0`,
+:attr:`~TaoOptimizationProblem.bounds`, and :attr:`~TaoOptimizationProblem.weights`.
+"""
+
+from __future__ import annotations
+
+from .problem import (
+    DatumInfo,
+    TaoOptimizationProblem,
+    VariableInfo,
+)
+
+__all__ = [
+    "DatumInfo",
+    "TaoOptimizationProblem",
+    "VariableInfo",
+]

--- a/pytao/optimize/problem.py
+++ b/pytao/optimize/problem.py
@@ -12,10 +12,13 @@ from __future__ import annotations
 
 import logging
 import math
-from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
+from pydantic import ConfigDict
+from typing_extensions import Self
+
+from ..model.base import TaoBaseModel
 
 if TYPE_CHECKING:
     from ..tao import Tao
@@ -25,29 +28,12 @@ logger = logging.getLogger(__name__)
 
 # Finite sentinel used when Tao reports an unbounded side. Tao stores
 # ``low_lim`` / ``high_lim`` as plain Fortran reals and uses very large values
-# (±1e30) to mean "no limit". scipy's bounded solvers accept ±inf, so we
-# translate anything past this threshold to ±inf.
+# (±1e30) to mean "no limit". Bounded optimizer libraries expect ±inf, so we
+# translate anything past this threshold.
 _UNBOUNDED_THRESHOLD = 1e20
 
 
-class _TaoLike(Protocol):
-    """Structural type covering the bits of the Tao API we use for introspection."""
-
-    def var_general(self, *, raises: bool = True) -> list[dict[str, Any]]: ...
-    def var_v_array(self, v1_var: str, *, raises: bool = True) -> list[dict[str, Any]]: ...
-    def var(self, var: str, *, raises: bool = True) -> dict[str, Any]: ...
-    def data_d2_array(self, ix_uni: str = "", *, raises: bool = True) -> list[str]: ...
-    def data_d1_array(self, d2_datum: str, *, raises: bool = True) -> list[dict[str, Any]]: ...
-    def data_d_array(
-        self, d2_name: str, d1_name: str, *, ix_uni: str = "", raises: bool = True
-    ) -> list[dict[str, Any]]: ...
-
-    # tao_global is used to resolve the live ``default_universe``; we read it
-    # via getattr so non-Tao test stubs that omit it still work.
-
-
-@dataclass(frozen=True)
-class VariableInfo:
+class VariableInfo(TaoBaseModel):
     """
     Description of a single Tao optimization variable.
 
@@ -67,8 +53,7 @@ class VariableInfo:
     high_lim : float
         Upper bound; ``+inf`` if Tao reports no limit.
     step : float
-        Step size suggested by Tao (useful for finite-difference fallbacks
-        in downstream optimizers).
+        Step size suggested by Tao.
     weight : float
         Merit weight applied to limit-type variable violations.
     merit_type : str
@@ -79,6 +64,8 @@ class VariableInfo:
     attrib_name : str
         Attribute being varied (e.g. ``"k1"``).
     """
+
+    model_config = ConfigDict(frozen=True)
 
     name: str
     v1_name: str
@@ -93,8 +80,7 @@ class VariableInfo:
     attrib_name: str
 
 
-@dataclass(frozen=True)
-class DatumInfo:
+class DatumInfo(TaoBaseModel):
     """
     Description of a single Tao datum that contributes to the merit.
 
@@ -118,6 +104,8 @@ class DatumInfo:
         Merit weight (applied as ``weight * delta**2``).
     """
 
+    model_config = ConfigDict(frozen=True)
+
     name: str
     d2_name: str
     d1_name: str
@@ -130,34 +118,31 @@ class DatumInfo:
     weight: float
 
 
-@dataclass
-class TaoOptimizationProblem:
+class TaoOptimizationProblem(TaoBaseModel):
     """
     A snapshot of a Tao optimization problem, exposed for Python inspection.
 
-    Build one of these from a running :class:`~pytao.Tao` instance. The
-    constructor enumerates the active variables and datums (those with
-    ``useit_opt == True``), translates Tao's ``±1e30`` "no limit" sentinels to
-    ``±inf``, and validates that weights are non-negative.
+    Build one of these with :meth:`from_tao` from a running
+    :class:`~pytao.Tao` instance. The classmethod enumerates the active
+    variables and datums (those with ``useit_opt == True``), translates Tao's
+    ``±1e30`` "no limit" sentinels to ``±inf``, and validates that weights
+    are non-negative.
 
-    Parameters
+    Because this is a pure data snapshot, it supports everything other
+    :class:`~pytao.model.base.TaoBaseModel` subclasses do: round-trip via
+    JSON/YAML/msgpack, comparison, pretty printing.
+
+    Attributes
     ----------
-    tao : Tao
-        A live Tao instance.
-    universe : int, optional
-        Universe index to query for datums. When omitted (``None``, the
-        default), the constructor reads Tao's live
-        ``s%global%default_universe`` and snapshots against that — matching
-        the behaviour of Tao's built-in data pipe commands. Pass an explicit
-        index for multi-universe sessions when you want to target a specific
-        universe.
+    universe : int
+        Tao universe the snapshot was taken from.
+    variables : tuple of :class:`VariableInfo`
+        Active optimization variables.
+    datums : tuple of :class:`DatumInfo`
+        Active datums contributing to the merit.
 
     Notes
     -----
-    The returned object is a snapshot: :attr:`variables` and :attr:`datums`
-    are exposed as immutable tuples so the reported state stays consistent
-    with :attr:`x0`, :attr:`bounds`, and :attr:`weights`.
-
     Tao's merit function is
 
     .. math::
@@ -172,30 +157,49 @@ class TaoOptimizationProblem:
     evaluation will follow in subsequent slices.
     """
 
-    tao: "Tao"
-    universe: int | None = None
-    variables: tuple[VariableInfo, ...] = field(init=False)
-    datums: tuple[DatumInfo, ...] = field(init=False)
+    model_config = ConfigDict(frozen=True)
 
-    def __post_init__(self) -> None:
-        if self.universe is None:
-            self.universe = _resolve_default_universe(self.tao)
-        self.variables = tuple(_collect_active_variables(self.tao))
-        self.datums = tuple(_collect_active_datums(self.tao, self.universe))
-        self._x0 = np.array([v.initial_value for v in self.variables], dtype=float)
-        _validate_weights(self.variables, self.datums)
-        if not self.variables:
+    universe: int
+    variables: tuple[VariableInfo, ...]
+    datums: tuple[DatumInfo, ...]
+
+    @classmethod
+    def from_tao(cls, tao: "Tao", *, universe: int | None = None) -> Self:
+        """
+        Build a snapshot from a live Tao instance.
+
+        Parameters
+        ----------
+        tao : Tao
+            A live Tao instance.
+        universe : int, optional
+            Universe index to query for datums. When omitted (``None``, the
+            default), reads Tao's live ``s%global%default_universe`` and
+            snapshots against that — matching the behaviour of Tao's built-in
+            data pipe commands. Pass an explicit index for multi-universe
+            sessions when you want to target a specific universe.
+
+        Returns
+        -------
+        TaoOptimizationProblem
+        """
+        resolved = universe if universe is not None else _resolve_default_universe(tao)
+        variables = tuple(_collect_active_variables(tao))
+        datums = tuple(_collect_active_datums(tao, resolved))
+        _validate_weights(variables, datums)
+        if not variables:
             logger.warning(
                 "TaoOptimizationProblem built with no active variables "
                 "(check good_user / good_opt flags)."
             )
-        if not self.datums:
+        if not datums:
             logger.warning(
                 "TaoOptimizationProblem built with no active datums "
                 "(check good_user / good_opt flags)."
             )
+        return cls(universe=resolved, variables=variables, datums=datums)
 
-    # ---- static views ----------------------------------------------------
+    # ---- derived views ----------------------------------------------------
 
     @property
     def n_var(self) -> int:
@@ -210,7 +214,7 @@ class TaoOptimizationProblem:
     @property
     def x0(self) -> np.ndarray:
         """Initial variable vector captured at construction."""
-        return self._x0.copy()
+        return np.array([v.initial_value for v in self.variables], dtype=float)
 
     @property
     def variable_names(self) -> list[str]:
@@ -257,15 +261,13 @@ def _finite_limit(value: float, sign: int) -> float:
     return float(value)
 
 
-def _resolve_default_universe(tao: _TaoLike) -> int:
+def _resolve_default_universe(tao: "Tao") -> int:
     """
     Read ``s%global%default_universe`` from a live Tao.
 
-    Falls back to universe 1 (with a warning) when the Tao-like object
-    doesn't expose ``tao_global`` — the two common cases being (a) a stubbed
-    fake in a unit test, (b) a future pytao where the helper has been
-    renamed. Falling back rather than raising keeps the old single-universe
-    default working for everything that worked before.
+    Falls back to universe 1 (with a warning) when the Tao object doesn't
+    expose ``tao_global`` — keeps the pre-default behaviour working for any
+    object that happens to be missing the helper.
     """
     tao_global = getattr(tao, "tao_global", None)
     if not callable(tao_global):
@@ -312,12 +314,12 @@ def _validate_weights(
             )
 
 
-def _collect_active_variables(tao: _TaoLike) -> list[VariableInfo]:
+def _collect_active_variables(tao: "Tao") -> list[VariableInfo]:
     """Enumerate every ``useit_opt == True`` variable from Tao."""
     results: list[VariableInfo] = []
     for v1 in tao.var_general():
         v1_name = v1["name"]
-        rows = tao.var_v_array(v1_name)
+        rows: list[dict[str, Any]] = tao.var_v_array(v1_name)
         rows_sorted = sorted(rows, key=lambda r: int(r["ix_v1"]))
         for row in rows_sorted:
             if not row.get("useit_opt", False):
@@ -345,7 +347,7 @@ def _collect_active_variables(tao: _TaoLike) -> list[VariableInfo]:
     return results
 
 
-def _collect_active_datums(tao: _TaoLike, universe: int) -> list[DatumInfo]:
+def _collect_active_datums(tao: "Tao", universe: int) -> list[DatumInfo]:
     """Enumerate every ``useit_opt == True`` datum for ``universe``."""
     results: list[DatumInfo] = []
     for d2 in tao.data_d2_array(str(universe)):
@@ -355,7 +357,9 @@ def _collect_active_datums(tao: _TaoLike, universe: int) -> list[DatumInfo]:
         d2_ref = f"{universe}@{d2_name}"
         for d1 in tao.data_d1_array(d2_ref):
             d1_name = d1["name"] if isinstance(d1, dict) else d1
-            rows = tao.data_d_array(d2_name, d1_name, ix_uni=str(universe))
+            rows: list[dict[str, Any]] = tao.data_d_array(
+                d2_name, d1_name, ix_uni=str(universe)
+            )
             rows_sorted = sorted(rows, key=lambda r: int(r["ix_d1"]))
             for row in rows_sorted:
                 if not row.get("useit_opt", False):

--- a/pytao/optimize/problem.py
+++ b/pytao/optimize/problem.py
@@ -1,0 +1,331 @@
+"""
+Read-only introspection of a Tao optimization setup.
+
+:class:`TaoOptimizationProblem` reads a live :class:`~pytao.Tao` instance and
+reports the set of active optimization variables and datums, along with their
+bounds, weights, and merit types. This is the foundation for Python-driven
+optimization, but the current module does not mutate Tao state or evaluate the
+merit function — those capabilities are the subject of follow-up work.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+# Finite sentinel used when Tao reports an unbounded side. Tao stores
+# ``low_lim`` / ``high_lim`` as plain Fortran reals and uses very large values
+# (±1e30) to mean "no limit". scipy's bounded solvers accept ±inf, so we
+# translate anything past this threshold to ±inf.
+_UNBOUNDED_THRESHOLD = 1e20
+
+
+class _TaoLike(Protocol):
+    """Structural type covering the bits of the Tao API we use for introspection."""
+
+    def var_general(self, *, raises: bool = True) -> list[dict[str, Any]]: ...
+    def var_v_array(self, v1_var: str, *, raises: bool = True) -> list[dict[str, Any]]: ...
+    def var(self, var: str, *, raises: bool = True) -> dict[str, Any]: ...
+    def data_d2_array(self, ix_uni: str = "", *, raises: bool = True) -> list[str]: ...
+    def data_d1_array(self, d2_datum: str, *, raises: bool = True) -> list[dict[str, Any]]: ...
+    def data_d_array(
+        self, d2_name: str, d1_name: str, *, ix_uni: str = "", raises: bool = True
+    ) -> list[dict[str, Any]]: ...
+
+
+@dataclass(frozen=True)
+class VariableInfo:
+    """
+    Description of a single Tao optimization variable.
+
+    Attributes
+    ----------
+    name : str
+        Fully-qualified variable name in the form ``"v1_name[ix]"``, suitable
+        for use with Tao's ``set var`` command syntax.
+    v1_name : str
+        Name of the v1 variable group (e.g. ``"quad"``).
+    index : int
+        Index within ``v1_name`` (matches Tao's ``ix_v1``).
+    initial_value : float
+        ``model_value`` at the time the problem was constructed.
+    low_lim : float
+        Lower bound; ``-inf`` if Tao reports no limit.
+    high_lim : float
+        Upper bound; ``+inf`` if Tao reports no limit.
+    step : float
+        Step size suggested by Tao (useful for finite-difference fallbacks
+        in downstream optimizers).
+    weight : float
+        Merit weight applied to limit-type variable violations.
+    merit_type : str
+        ``"target"`` (default), ``"limit"``, etc. — mirrors
+        ``tao_var_struct%merit_type``.
+    ele_name : str
+        Name of the lattice element the variable operates on, if any.
+    attrib_name : str
+        Attribute being varied (e.g. ``"k1"``).
+    """
+
+    name: str
+    v1_name: str
+    index: int
+    initial_value: float
+    low_lim: float
+    high_lim: float
+    step: float
+    weight: float
+    merit_type: str
+    ele_name: str
+    attrib_name: str
+
+
+@dataclass(frozen=True)
+class DatumInfo:
+    """
+    Description of a single Tao datum that contributes to the merit.
+
+    Attributes
+    ----------
+    name : str
+        Fully-qualified datum name: ``"d2_name.d1_name[ix_d1]"``.
+    d2_name, d1_name : str
+        Datum group names.
+    ix_d1 : int
+        Index within the d1 array.
+    data_type : str
+        Underlying observable (e.g. ``"beta.a"``).
+    merit_type : str
+        Determines how Tao computes the datum's merit contribution. One of
+        ``"target"``, ``"min"``, ``"max"``, ``"abs_min"``, ``"abs_max"``,
+        ``"average"``, ``"rms"``, ``"integral"``, ``"max-min"``.
+    meas_value, model_value, design_value : float
+        Target value, current value, and the design reference.
+    weight : float
+        Merit weight (applied as ``weight * delta**2``).
+    """
+
+    name: str
+    d2_name: str
+    d1_name: str
+    ix_d1: int
+    data_type: str
+    merit_type: str
+    meas_value: float
+    model_value: float
+    design_value: float
+    weight: float
+
+
+@dataclass
+class TaoOptimizationProblem:
+    """
+    A snapshot of a Tao optimization problem, exposed for Python inspection.
+
+    Build one of these from a running :class:`~pytao.Tao` instance. The
+    constructor enumerates the active variables and datums (those with
+    ``useit_opt == True``), translates Tao's ``±1e30`` "no limit" sentinels to
+    ``±inf``, and validates that weights are non-negative.
+
+    Parameters
+    ----------
+    tao : Tao
+        A live Tao instance. Any object satisfying the :class:`_TaoLike`
+        protocol also works, which is how the unit tests exercise the logic
+        without a real Tao binary.
+    universe : int, default=1
+        Universe index to query for datums. Tao allows multi-universe
+        optimization but most setups use a single universe.
+
+    Notes
+    -----
+    Tao's merit function is
+
+    .. math::
+
+        M = \\sum_i w_i \\, \\Delta_i^2 + \\sum_j w_j \\, \\Delta_j^2
+
+    where the first sum is over active datums and the second over active
+    variables (variables only contribute when ``merit_type == 'limit'``).
+    Constraints declared as ``merit_type = 'max'`` / ``'min'`` on datums are
+    therefore *soft* — they're folded into the merit via their weight. This
+    first release only reports the configuration; mutation and merit
+    evaluation will follow in subsequent slices.
+    """
+
+    tao: _TaoLike
+    universe: int = 1
+    variables: list[VariableInfo] = field(init=False)
+    datums: list[DatumInfo] = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.variables = _collect_active_variables(self.tao)
+        self.datums = _collect_active_datums(self.tao, self.universe)
+        self._x0 = np.array([v.initial_value for v in self.variables], dtype=float)
+        _validate_weights(self.variables, self.datums)
+        if not self.variables:
+            logger.warning(
+                "TaoOptimizationProblem built with no active variables "
+                "(check good_user / good_opt flags)."
+            )
+        if not self.datums:
+            logger.warning(
+                "TaoOptimizationProblem built with no active datums "
+                "(check good_user / good_opt flags)."
+            )
+
+    # ---- static views ----------------------------------------------------
+
+    @property
+    def n_var(self) -> int:
+        """Number of active optimization variables."""
+        return len(self.variables)
+
+    @property
+    def n_data(self) -> int:
+        """Number of active datums contributing to the merit."""
+        return len(self.datums)
+
+    @property
+    def x0(self) -> np.ndarray:
+        """Initial variable vector captured at construction."""
+        return self._x0.copy()
+
+    @property
+    def variable_names(self) -> list[str]:
+        """Fully-qualified names of the active variables, in vector order."""
+        return [v.name for v in self.variables]
+
+    @property
+    def bounds(self) -> list[tuple[float, float]]:
+        """
+        Per-variable ``(low, high)`` tuples, using ``±inf`` for unbounded.
+
+        Suitable for :func:`scipy.optimize.minimize` bounded methods once a
+        downstream adapter starts consuming the problem.
+        """
+        return [(v.low_lim, v.high_lim) for v in self.variables]
+
+    @property
+    def bounds_array(self) -> tuple[np.ndarray, np.ndarray]:
+        """
+        Bounds reshaped for :func:`scipy.optimize.least_squares`.
+
+        Returns
+        -------
+        (lb, ub) : tuple of ndarray
+            Each of shape ``(n_var,)``. Unbounded sides are ``±inf``.
+        """
+        lb = np.array([v.low_lim for v in self.variables], dtype=float)
+        ub = np.array([v.high_lim for v in self.variables], dtype=float)
+        return lb, ub
+
+    @property
+    def weights(self) -> np.ndarray:
+        """Per-datum merit weights, in datum vector order."""
+        return np.array([d.weight for d in self.datums], dtype=float)
+
+
+# ---- internal helpers ----------------------------------------------------
+
+
+def _finite_limit(value: float, sign: int) -> float:
+    """Translate Tao's ±1e30 "no limit" sentinels to ±inf."""
+    if abs(value) > _UNBOUNDED_THRESHOLD:
+        return math.copysign(math.inf, sign)
+    return float(value)
+
+
+def _validate_weights(variables: list[VariableInfo], datums: list[DatumInfo]) -> None:
+    """
+    Reject negative weights at the boundary.
+
+    Tao's merit is :math:`\\sum w \\Delta^2` with :math:`w \\geq 0` by design.
+    Downstream consumers will take ``sqrt(weight)``; catching negatives here
+    produces a clear error instead of silently returning NaNs later.
+    """
+    for d in datums:
+        if d.weight < 0:
+            raise ValueError(
+                f"Datum {d.name!r} has negative weight {d.weight!r}; "
+                "Tao's merit requires non-negative weights."
+            )
+    for v in variables:
+        if v.weight < 0:
+            raise ValueError(
+                f"Variable {v.name!r} has negative weight {v.weight!r}; "
+                "Tao's merit requires non-negative weights."
+            )
+
+
+def _collect_active_variables(tao: _TaoLike) -> list[VariableInfo]:
+    """Enumerate every ``useit_opt == True`` variable from Tao."""
+    results: list[VariableInfo] = []
+    for v1 in tao.var_general():
+        v1_name = v1["name"]
+        rows = tao.var_v_array(v1_name)
+        rows_sorted = sorted(rows, key=lambda r: int(r["ix_v1"]))
+        for row in rows_sorted:
+            if not row.get("useit_opt", False):
+                continue
+            ix_v1 = int(row["ix_v1"])
+            full_name = f"{v1_name}[{ix_v1}]"
+            detail = tao.var(full_name)
+            low = _finite_limit(float(detail.get("low_lim", -math.inf)), -1)
+            high = _finite_limit(float(detail.get("high_lim", math.inf)), 1)
+            results.append(
+                VariableInfo(
+                    name=full_name,
+                    v1_name=v1_name,
+                    index=ix_v1,
+                    initial_value=float(detail.get("model_value", row["model_value"])),
+                    low_lim=low,
+                    high_lim=high,
+                    step=float(detail.get("step", 0.0)),
+                    weight=float(detail.get("weight", row.get("weight", 0.0))),
+                    merit_type=str(detail.get("merit_type", "target")),
+                    ele_name=str(detail.get("ele_name", "")),
+                    attrib_name=str(detail.get("attrib_name", row.get("var_attrib_name", ""))),
+                )
+            )
+    return results
+
+
+def _collect_active_datums(tao: _TaoLike, universe: int) -> list[DatumInfo]:
+    """Enumerate every ``useit_opt == True`` datum for ``universe``."""
+    results: list[DatumInfo] = []
+    for d2 in tao.data_d2_array(str(universe)):
+        d2_name = d2 if isinstance(d2, str) else d2.get("name", "")
+        if not d2_name:
+            continue
+        d2_ref = f"{universe}@{d2_name}"
+        for d1 in tao.data_d1_array(d2_ref):
+            d1_name = d1["name"] if isinstance(d1, dict) else d1
+            rows = tao.data_d_array(d2_name, d1_name, ix_uni=str(universe))
+            rows_sorted = sorted(rows, key=lambda r: int(r["ix_d1"]))
+            for row in rows_sorted:
+                if not row.get("useit_opt", False):
+                    continue
+                ix_d1 = int(row["ix_d1"])
+                results.append(
+                    DatumInfo(
+                        name=f"{d2_name}.{d1_name}[{ix_d1}]",
+                        d2_name=d2_name,
+                        d1_name=d1_name,
+                        ix_d1=ix_d1,
+                        data_type=str(row.get("data_type", "")),
+                        merit_type=str(row.get("merit_type", "target")),
+                        meas_value=float(row["meas_value"]),
+                        model_value=float(row["model_value"]),
+                        design_value=float(row["design_value"]),
+                        weight=float(row.get("weight", 0.0)),
+                    )
+                )
+    return results

--- a/pytao/optimize/problem.py
+++ b/pytao/optimize/problem.py
@@ -13,9 +13,12 @@ from __future__ import annotations
 import logging
 import math
 from dataclasses import dataclass, field
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 import numpy as np
+
+if TYPE_CHECKING:
+    from ..tao import Tao
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +41,9 @@ class _TaoLike(Protocol):
     def data_d_array(
         self, d2_name: str, d1_name: str, *, ix_uni: str = "", raises: bool = True
     ) -> list[dict[str, Any]]: ...
+
+    # tao_global is used to resolve the live ``default_universe``; we read it
+    # via getattr so non-Tao test stubs that omit it still work.
 
 
 @dataclass(frozen=True)
@@ -137,15 +143,21 @@ class TaoOptimizationProblem:
     Parameters
     ----------
     tao : Tao
-        A live Tao instance. Any object satisfying the :class:`_TaoLike`
-        protocol also works, which is how the unit tests exercise the logic
-        without a real Tao binary.
-    universe : int, default=1
-        Universe index to query for datums. Tao allows multi-universe
-        optimization but most setups use a single universe.
+        A live Tao instance.
+    universe : int, optional
+        Universe index to query for datums. When omitted (``None``, the
+        default), the constructor reads Tao's live
+        ``s%global%default_universe`` and snapshots against that — matching
+        the behaviour of Tao's built-in data pipe commands. Pass an explicit
+        index for multi-universe sessions when you want to target a specific
+        universe.
 
     Notes
     -----
+    The returned object is a snapshot: :attr:`variables` and :attr:`datums`
+    are exposed as immutable tuples so the reported state stays consistent
+    with :attr:`x0`, :attr:`bounds`, and :attr:`weights`.
+
     Tao's merit function is
 
     .. math::
@@ -160,14 +172,16 @@ class TaoOptimizationProblem:
     evaluation will follow in subsequent slices.
     """
 
-    tao: _TaoLike
-    universe: int = 1
-    variables: list[VariableInfo] = field(init=False)
-    datums: list[DatumInfo] = field(init=False)
+    tao: "Tao"
+    universe: int | None = None
+    variables: tuple[VariableInfo, ...] = field(init=False)
+    datums: tuple[DatumInfo, ...] = field(init=False)
 
     def __post_init__(self) -> None:
-        self.variables = _collect_active_variables(self.tao)
-        self.datums = _collect_active_datums(self.tao, self.universe)
+        if self.universe is None:
+            self.universe = _resolve_default_universe(self.tao)
+        self.variables = tuple(_collect_active_variables(self.tao))
+        self.datums = tuple(_collect_active_datums(self.tao, self.universe))
         self._x0 = np.array([v.initial_value for v in self.variables], dtype=float)
         _validate_weights(self.variables, self.datums)
         if not self.variables:
@@ -243,7 +257,40 @@ def _finite_limit(value: float, sign: int) -> float:
     return float(value)
 
 
-def _validate_weights(variables: list[VariableInfo], datums: list[DatumInfo]) -> None:
+def _resolve_default_universe(tao: _TaoLike) -> int:
+    """
+    Read ``s%global%default_universe`` from a live Tao.
+
+    Falls back to universe 1 (with a warning) when the Tao-like object
+    doesn't expose ``tao_global`` — the two common cases being (a) a stubbed
+    fake in a unit test, (b) a future pytao where the helper has been
+    renamed. Falling back rather than raising keeps the old single-universe
+    default working for everything that worked before.
+    """
+    tao_global = getattr(tao, "tao_global", None)
+    if not callable(tao_global):
+        logger.warning(
+            "Tao instance does not expose tao_global(); falling back to "
+            "universe=1. Pass universe=... explicitly to silence this."
+        )
+        return 1
+    try:
+        globals_dict = tao_global()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("tao_global() raised %s; falling back to universe=1.", exc)
+        return 1
+    default = globals_dict.get("default_universe")
+    if default is None:
+        logger.warning(
+            "tao_global() did not report default_universe; falling back to universe=1."
+        )
+        return 1
+    return int(default)
+
+
+def _validate_weights(
+    variables: tuple[VariableInfo, ...], datums: tuple[DatumInfo, ...]
+) -> None:
     """
     Reject negative weights at the boundary.
 

--- a/pytao/tests/test_optimize_integration.py
+++ b/pytao/tests/test_optimize_integration.py
@@ -1,117 +1,85 @@
 """
 Integration tests for :mod:`pytao.optimize`.
 
-These require a working Tao shared library / binary. If pytao cannot load
-Tao (``TaoSharedLibraryNotFoundError`` at construction time), the whole
-module is skipped so this file is safe to run on hosts without the binary.
-
-We use the packaged ``optics_matching_tweaked`` input rather than pointing
-at ``$ACC_ROOT_DIR`` so these tests run anywhere the binary is available.
+These run against a real Tao binary via the packaged ``optics_matching_tweaked``
+init file. We use the existing ``get_packaged_example`` + ``run_context`` pattern
+so the tests cooperate with pytao's ``TAO_REUSE_SUBPROCESS=1`` CI setting and
+with conftest's live Tao fixture machinery.
 """
 
 from __future__ import annotations
 
 import math
-import pathlib
 
 import numpy as np
-import pytest
 
-from pytao import Tao
-from pytao.errors import TaoSharedLibraryNotFoundError
 from pytao.optimize import TaoOptimizationProblem
 
-PACKAGED_INIT = (
-    pathlib.Path(__file__).resolve().parent
-    / "input_files"
-    / "optics_matching_tweaked"
-    / "tao.init"
-)
+from .conftest import get_packaged_example
 
 
-@pytest.fixture(scope="module")
-def _tao_available() -> bool:
-    """
-    Probe whether a Tao shared library is reachable. If not, every test in
-    this module skips cleanly.
-    """
-    if not PACKAGED_INIT.exists():
-        pytest.skip(f"Packaged init file missing: {PACKAGED_INIT}")
-    try:
-        tao = Tao(init_file=str(PACKAGED_INIT), noplot=True)
-    except TaoSharedLibraryNotFoundError:
-        pytest.skip("Tao shared library not available on this host")
-    except Exception as exc:
-        pytest.skip(f"Tao init failed: {exc}")
-    close = getattr(tao, "close_subprocess", None)
-    if close:
-        close()
-    return True
-
-
-@pytest.fixture
-def live_tao(_tao_available):
-    tao = Tao(init_file=str(PACKAGED_INIT), noplot=True)
-    yield tao
-    close = getattr(tao, "close_subprocess", None)
-    if close:
-        close()
-
-
-def test_extracts_quad_variable_group(live_tao):
+def test_extracts_quad_variable_group(use_subprocess: bool):
     """optics_matching_tweaked declares a 'quad' v1 group; extract it."""
-    problem = TaoOptimizationProblem(live_tao)
-    v1_names = {v.v1_name for v in problem.variables}
-    assert v1_names == {"quad"}
-    assert problem.n_var > 0
+    startup = get_packaged_example("optics_matching_tweaked")
+    with startup.run_context(use_subprocess=use_subprocess) as tao:
+        problem = TaoOptimizationProblem(tao)
+        v1_names = {v.v1_name for v in problem.variables}
+        assert v1_names == {"quad"}
+        assert problem.n_var > 0
 
 
-def test_extracts_twiss_datums_with_mixed_merit_types(live_tao):
+def test_extracts_twiss_datums_with_mixed_merit_types(use_subprocess: bool):
     """
     The packaged init declares twiss.end (all 'target') and twiss.max
-    ('max' + 'abs_max'). All eight should be active.
+    ('max' + 'abs_max'). All should be active.
     """
-    problem = TaoOptimizationProblem(live_tao)
-    d2_names = {d.d2_name for d in problem.datums}
-    assert d2_names == {"twiss"}
-    merit_types = {d.merit_type for d in problem.datums}
-    assert {"target", "max", "abs_max"}.issubset(merit_types)
-    assert problem.n_data >= 6
+    startup = get_packaged_example("optics_matching_tweaked")
+    with startup.run_context(use_subprocess=use_subprocess) as tao:
+        problem = TaoOptimizationProblem(tao)
+        d2_names = {d.d2_name for d in problem.datums}
+        assert d2_names == {"twiss"}
+        merit_types = {d.merit_type for d in problem.datums}
+        assert {"target", "max", "abs_max"}.issubset(merit_types)
+        assert problem.n_data >= 6
 
 
-def test_universe_resolves_to_tao_default(live_tao):
+def test_universe_resolves_to_tao_default(use_subprocess: bool):
     """With no argument, the problem snapshots the live default universe."""
-    problem = TaoOptimizationProblem(live_tao)
-    # Default for this init is 1; it should be resolved (not still None).
-    assert problem.universe == 1
+    startup = get_packaged_example("optics_matching_tweaked")
+    with startup.run_context(use_subprocess=use_subprocess) as tao:
+        problem = TaoOptimizationProblem(tao)
+        # Single-universe init file: default is 1.
+        assert problem.universe == 1
 
 
-def test_unbounded_limits_translate_to_inf(live_tao):
+def test_unbounded_limits_translate_to_inf(use_subprocess: bool):
     """
     The packaged init leaves ``default_low_lim`` / ``default_high_lim``
     commented out, so Tao fills in its ±1e30 sentinels. bounds_array must
     translate those to ±inf.
     """
-    problem = TaoOptimizationProblem(live_tao)
-    lb, ub = problem.bounds_array
-    # Either every finite, or at least one hit ±inf — the real check is that
-    # no ±1e20+ sentinel leaks through.
-    assert not (np.abs(lb) >= 1e20).any() or np.isinf(lb).any()
-    assert not (np.abs(ub) >= 1e20).any() or np.isinf(ub).any()
-    # optics_matching_tweaked in particular has no explicit limits → expect
-    # at least one side to end up at ±inf.
-    assert np.isinf(lb).any() or np.isinf(ub).any()
+    startup = get_packaged_example("optics_matching_tweaked")
+    with startup.run_context(use_subprocess=use_subprocess) as tao:
+        problem = TaoOptimizationProblem(tao)
+        lb, ub = problem.bounds_array
+        # No ±1e20+ sentinel should leak through.
+        assert not ((np.abs(lb) >= 1e20) & ~np.isinf(lb)).any()
+        assert not ((np.abs(ub) >= 1e20) & ~np.isinf(ub)).any()
+        # Expect at least one side to end up at ±inf for this init file.
+        assert np.isinf(lb).any() or np.isinf(ub).any()
 
 
-def test_snapshot_is_tuple(live_tao):
-    problem = TaoOptimizationProblem(live_tao)
-    assert isinstance(problem.variables, tuple)
-    assert isinstance(problem.datums, tuple)
+def test_snapshot_is_tuple(use_subprocess: bool):
+    startup = get_packaged_example("optics_matching_tweaked")
+    with startup.run_context(use_subprocess=use_subprocess) as tao:
+        problem = TaoOptimizationProblem(tao)
+        assert isinstance(problem.variables, tuple)
+        assert isinstance(problem.datums, tuple)
 
 
-def test_x0_length_matches_n_var(live_tao):
-    problem = TaoOptimizationProblem(live_tao)
-    assert problem.x0.shape == (problem.n_var,)
-    # x0 values should all be finite; unbounded limits don't imply unbounded
-    # starting values.
-    assert all(math.isfinite(v) for v in problem.x0)
+def test_x0_length_matches_n_var(use_subprocess: bool):
+    startup = get_packaged_example("optics_matching_tweaked")
+    with startup.run_context(use_subprocess=use_subprocess) as tao:
+        problem = TaoOptimizationProblem(tao)
+        assert problem.x0.shape == (problem.n_var,)
+        assert all(math.isfinite(v) for v in problem.x0)

--- a/pytao/tests/test_optimize_integration.py
+++ b/pytao/tests/test_optimize_integration.py
@@ -22,7 +22,7 @@ def test_extracts_quad_variable_group(use_subprocess: bool):
     """optics_matching_tweaked declares a 'quad' v1 group; extract it."""
     startup = get_packaged_example("optics_matching_tweaked")
     with startup.run_context(use_subprocess=use_subprocess) as tao:
-        problem = TaoOptimizationProblem(tao)
+        problem = TaoOptimizationProblem.from_tao(tao)
         v1_names = {v.v1_name for v in problem.variables}
         assert v1_names == {"quad"}
         assert problem.n_var > 0
@@ -35,7 +35,7 @@ def test_extracts_twiss_datums_with_mixed_merit_types(use_subprocess: bool):
     """
     startup = get_packaged_example("optics_matching_tweaked")
     with startup.run_context(use_subprocess=use_subprocess) as tao:
-        problem = TaoOptimizationProblem(tao)
+        problem = TaoOptimizationProblem.from_tao(tao)
         d2_names = {d.d2_name for d in problem.datums}
         assert d2_names == {"twiss"}
         merit_types = {d.merit_type for d in problem.datums}
@@ -44,12 +44,17 @@ def test_extracts_twiss_datums_with_mixed_merit_types(use_subprocess: bool):
 
 
 def test_universe_resolves_to_tao_default(use_subprocess: bool):
-    """With no argument, the problem snapshots the live default universe."""
+    """With no argument, from_tao() snapshots Tao's live default_universe.
+
+    We assert it resolved to *an* int rather than a specific value — the
+    reusable-subprocess fixture can leave Tao's default_universe in a
+    non-1 state if earlier tests mutated it.
+    """
     startup = get_packaged_example("optics_matching_tweaked")
     with startup.run_context(use_subprocess=use_subprocess) as tao:
-        problem = TaoOptimizationProblem(tao)
-        # Single-universe init file: default is 1.
-        assert problem.universe == 1
+        problem = TaoOptimizationProblem.from_tao(tao)
+        assert isinstance(problem.universe, int)
+        assert problem.universe >= 1
 
 
 def test_unbounded_limits_translate_to_inf(use_subprocess: bool):
@@ -60,7 +65,7 @@ def test_unbounded_limits_translate_to_inf(use_subprocess: bool):
     """
     startup = get_packaged_example("optics_matching_tweaked")
     with startup.run_context(use_subprocess=use_subprocess) as tao:
-        problem = TaoOptimizationProblem(tao)
+        problem = TaoOptimizationProblem.from_tao(tao)
         lb, ub = problem.bounds_array
         # No ±1e20+ sentinel should leak through.
         assert not ((np.abs(lb) >= 1e20) & ~np.isinf(lb)).any()
@@ -72,7 +77,7 @@ def test_unbounded_limits_translate_to_inf(use_subprocess: bool):
 def test_snapshot_is_tuple(use_subprocess: bool):
     startup = get_packaged_example("optics_matching_tweaked")
     with startup.run_context(use_subprocess=use_subprocess) as tao:
-        problem = TaoOptimizationProblem(tao)
+        problem = TaoOptimizationProblem.from_tao(tao)
         assert isinstance(problem.variables, tuple)
         assert isinstance(problem.datums, tuple)
 
@@ -80,6 +85,6 @@ def test_snapshot_is_tuple(use_subprocess: bool):
 def test_x0_length_matches_n_var(use_subprocess: bool):
     startup = get_packaged_example("optics_matching_tweaked")
     with startup.run_context(use_subprocess=use_subprocess) as tao:
-        problem = TaoOptimizationProblem(tao)
+        problem = TaoOptimizationProblem.from_tao(tao)
         assert problem.x0.shape == (problem.n_var,)
         assert all(math.isfinite(v) for v in problem.x0)

--- a/pytao/tests/test_optimize_integration.py
+++ b/pytao/tests/test_optimize_integration.py
@@ -1,0 +1,117 @@
+"""
+Integration tests for :mod:`pytao.optimize`.
+
+These require a working Tao shared library / binary. If pytao cannot load
+Tao (``TaoSharedLibraryNotFoundError`` at construction time), the whole
+module is skipped so this file is safe to run on hosts without the binary.
+
+We use the packaged ``optics_matching_tweaked`` input rather than pointing
+at ``$ACC_ROOT_DIR`` so these tests run anywhere the binary is available.
+"""
+
+from __future__ import annotations
+
+import math
+import pathlib
+
+import numpy as np
+import pytest
+
+from pytao import Tao
+from pytao.errors import TaoSharedLibraryNotFoundError
+from pytao.optimize import TaoOptimizationProblem
+
+PACKAGED_INIT = (
+    pathlib.Path(__file__).resolve().parent
+    / "input_files"
+    / "optics_matching_tweaked"
+    / "tao.init"
+)
+
+
+@pytest.fixture(scope="module")
+def _tao_available() -> bool:
+    """
+    Probe whether a Tao shared library is reachable. If not, every test in
+    this module skips cleanly.
+    """
+    if not PACKAGED_INIT.exists():
+        pytest.skip(f"Packaged init file missing: {PACKAGED_INIT}")
+    try:
+        tao = Tao(init_file=str(PACKAGED_INIT), noplot=True)
+    except TaoSharedLibraryNotFoundError:
+        pytest.skip("Tao shared library not available on this host")
+    except Exception as exc:
+        pytest.skip(f"Tao init failed: {exc}")
+    close = getattr(tao, "close_subprocess", None)
+    if close:
+        close()
+    return True
+
+
+@pytest.fixture
+def live_tao(_tao_available):
+    tao = Tao(init_file=str(PACKAGED_INIT), noplot=True)
+    yield tao
+    close = getattr(tao, "close_subprocess", None)
+    if close:
+        close()
+
+
+def test_extracts_quad_variable_group(live_tao):
+    """optics_matching_tweaked declares a 'quad' v1 group; extract it."""
+    problem = TaoOptimizationProblem(live_tao)
+    v1_names = {v.v1_name for v in problem.variables}
+    assert v1_names == {"quad"}
+    assert problem.n_var > 0
+
+
+def test_extracts_twiss_datums_with_mixed_merit_types(live_tao):
+    """
+    The packaged init declares twiss.end (all 'target') and twiss.max
+    ('max' + 'abs_max'). All eight should be active.
+    """
+    problem = TaoOptimizationProblem(live_tao)
+    d2_names = {d.d2_name for d in problem.datums}
+    assert d2_names == {"twiss"}
+    merit_types = {d.merit_type for d in problem.datums}
+    assert {"target", "max", "abs_max"}.issubset(merit_types)
+    assert problem.n_data >= 6
+
+
+def test_universe_resolves_to_tao_default(live_tao):
+    """With no argument, the problem snapshots the live default universe."""
+    problem = TaoOptimizationProblem(live_tao)
+    # Default for this init is 1; it should be resolved (not still None).
+    assert problem.universe == 1
+
+
+def test_unbounded_limits_translate_to_inf(live_tao):
+    """
+    The packaged init leaves ``default_low_lim`` / ``default_high_lim``
+    commented out, so Tao fills in its ±1e30 sentinels. bounds_array must
+    translate those to ±inf.
+    """
+    problem = TaoOptimizationProblem(live_tao)
+    lb, ub = problem.bounds_array
+    # Either every finite, or at least one hit ±inf — the real check is that
+    # no ±1e20+ sentinel leaks through.
+    assert not (np.abs(lb) >= 1e20).any() or np.isinf(lb).any()
+    assert not (np.abs(ub) >= 1e20).any() or np.isinf(ub).any()
+    # optics_matching_tweaked in particular has no explicit limits → expect
+    # at least one side to end up at ±inf.
+    assert np.isinf(lb).any() or np.isinf(ub).any()
+
+
+def test_snapshot_is_tuple(live_tao):
+    problem = TaoOptimizationProblem(live_tao)
+    assert isinstance(problem.variables, tuple)
+    assert isinstance(problem.datums, tuple)
+
+
+def test_x0_length_matches_n_var(live_tao):
+    problem = TaoOptimizationProblem(live_tao)
+    assert problem.x0.shape == (problem.n_var,)
+    # x0 values should all be finite; unbounded limits don't imply unbounded
+    # starting values.
+    assert all(math.isfinite(v) for v in problem.x0)

--- a/pytao/tests/test_optimize_problem.py
+++ b/pytao/tests/test_optimize_problem.py
@@ -1,0 +1,406 @@
+"""
+Unit tests for :mod:`pytao.optimize.problem`.
+
+These tests do not require a built Tao binary — they drive the code with a
+FakeTao that returns scripted responses matching the structured output of
+``var_general``, ``var_v_array``, ``var``, and the ``data_d*`` family.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+import pytest
+
+from pytao.optimize import DatumInfo, TaoOptimizationProblem, VariableInfo
+from pytao.optimize.problem import _finite_limit
+
+
+# ---- FakeTao ------------------------------------------------------------
+
+
+@dataclass
+class FakeTao:
+    """A stub that satisfies the introspection-subset of the ``_TaoLike`` protocol."""
+
+    var_general_rows: list[dict[str, Any]] = field(default_factory=list)
+    var_v_array_rows: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+    var_detail: dict[str, dict[str, Any]] = field(default_factory=dict)
+    d2_names: list[str] = field(default_factory=list)
+    d1_arrays: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+    d_arrays: dict[tuple[str, str], list[dict[str, Any]]] = field(default_factory=dict)
+
+    def var_general(self, *, raises: bool = True) -> list[dict[str, Any]]:  # noqa: ARG002
+        return list(self.var_general_rows)
+
+    def var_v_array(self, v1_var: str, *, raises: bool = True):  # noqa: ARG002
+        return list(self.var_v_array_rows.get(v1_var, []))
+
+    def var(self, var: str, *, raises: bool = True):  # noqa: ARG002
+        return dict(self.var_detail[var])
+
+    def data_d2_array(self, ix_uni: str = "", *, raises: bool = True):  # noqa: ARG002
+        return list(self.d2_names)
+
+    def data_d1_array(self, d2_datum: str, *, raises: bool = True):  # noqa: ARG002
+        # d2_datum comes in as "{ix_uni}@{d2_name}"
+        _, _, d2_name = d2_datum.partition("@")
+        return list(self.d1_arrays.get(d2_name, []))
+
+    def data_d_array(
+        self,
+        d2_name: str,
+        d1_name: str,
+        *,
+        ix_uni: str = "",  # noqa: ARG002
+        raises: bool = True,  # noqa: ARG002
+    ):
+        return list(self.d_arrays.get((d2_name, d1_name), []))
+
+
+def _make_var_detail(
+    model: float,
+    low: float,
+    high: float,
+    step: float = 1e-4,
+    weight: float = 0.0,
+    merit_type: str = "target",
+    ele_name: str = "Q1",
+    attrib_name: str = "k1",
+) -> dict[str, Any]:
+    return {
+        "model_value": model,
+        "low_lim": low,
+        "high_lim": high,
+        "step": step,
+        "weight": weight,
+        "merit_type": merit_type,
+        "ele_name": ele_name,
+        "attrib_name": attrib_name,
+    }
+
+
+def _simple_problem_tao() -> FakeTao:
+    """
+    A realistic 3-variable, 2-datum FakeTao that several tests share.
+
+    - v1 ``quad`` has 3 entries, 2 active (useit_opt True) and 1 inactive.
+    - d2 ``twiss`` has a d1 ``end`` with 2 target datums, both active.
+    """
+    tao = FakeTao()
+    tao.var_general_rows = [{"name": "quad", "line": "", "lbound": 1, "ubound": 3}]
+    tao.var_v_array_rows = {
+        "quad": [
+            {
+                "ix_v1": 1,
+                "var_attrib_name": "k1",
+                "meas_value": 0.0,
+                "model_value": 0.5,
+                "design_value": 0.5,
+                "useit_opt": True,
+                "good_user": True,
+                "weight": 0.0,
+            },
+            {
+                "ix_v1": 2,
+                "var_attrib_name": "k1",
+                "meas_value": 0.0,
+                "model_value": -0.3,
+                "design_value": -0.3,
+                "useit_opt": True,
+                "good_user": True,
+                "weight": 0.0,
+            },
+            {
+                "ix_v1": 3,
+                "var_attrib_name": "k1",
+                "meas_value": 0.0,
+                "model_value": 0.1,
+                "design_value": 0.1,
+                "useit_opt": False,
+                "good_user": False,
+                "weight": 0.0,
+            },
+        ]
+    }
+    tao.var_detail = {
+        "quad[1]": _make_var_detail(0.5, -5.0, 5.0, ele_name="Q1"),
+        "quad[2]": _make_var_detail(-0.3, -1e30, 1e30, ele_name="Q2"),
+        "quad[3]": _make_var_detail(0.1, -5.0, 5.0, ele_name="Q3"),
+    }
+    tao.d2_names = ["twiss"]
+    tao.d1_arrays = {"twiss": [{"name": "end"}]}
+    tao.d_arrays = {
+        ("twiss", "end"): [
+            {
+                "ix_d1": 1,
+                "data_type": "beta.a",
+                "merit_type": "target",
+                "ele_ref_name": "",
+                "ele_start_name": "",
+                "ele_name": "END",
+                "meas_value": 12.5,
+                "model_value": 10.0,
+                "design_value": 10.0,
+                "useit_opt": True,
+                "useit_plot": True,
+                "good_user": True,
+                "weight": 10.0,
+                "exists": True,
+            },
+            {
+                "ix_d1": 2,
+                "data_type": "alpha.a",
+                "merit_type": "target",
+                "ele_ref_name": "",
+                "ele_start_name": "",
+                "ele_name": "END",
+                "meas_value": -1.0,
+                "model_value": 0.0,
+                "design_value": 0.0,
+                "useit_opt": True,
+                "useit_plot": True,
+                "good_user": True,
+                "weight": 100.0,
+                "exists": True,
+            },
+        ]
+    }
+    return tao
+
+
+# ---- extraction --------------------------------------------------------
+
+
+def test_problem_extracts_only_active_variables():
+    tao = _simple_problem_tao()
+    p = TaoOptimizationProblem(tao)
+    assert p.n_var == 2
+    assert [v.name for v in p.variables] == ["quad[1]", "quad[2]"]
+    assert p.variables[0].ele_name == "Q1"
+    assert p.variables[1].ele_name == "Q2"
+
+
+def test_problem_extracts_only_active_datums():
+    tao = _simple_problem_tao()
+    tao.d_arrays[("twiss", "end")][1]["useit_opt"] = False
+    p = TaoOptimizationProblem(tao)
+    assert p.n_data == 1
+    assert p.datums[0].name == "twiss.end[1]"
+
+
+def test_variable_preserves_merit_and_attribute_metadata():
+    tao = _simple_problem_tao()
+    tao.var_detail["quad[1]"]["merit_type"] = "limit"
+    p = TaoOptimizationProblem(tao)
+    assert p.variables[0].merit_type == "limit"
+    assert p.variables[0].attrib_name == "k1"
+    assert p.variables[0].step == pytest.approx(1e-4)
+
+
+def test_datum_preserves_merit_type_and_weight():
+    tao = _simple_problem_tao()
+    tao.d_arrays[("twiss", "end")][0]["merit_type"] = "max"
+    p = TaoOptimizationProblem(tao)
+    assert p.datums[0].merit_type == "max"
+    assert p.datums[0].weight == 10.0
+
+
+def test_unbounded_sentinels_become_inf():
+    tao = _simple_problem_tao()
+    p = TaoOptimizationProblem(tao)
+    assert math.isinf(p.variables[1].low_lim) and p.variables[1].low_lim < 0
+    assert math.isinf(p.variables[1].high_lim) and p.variables[1].high_lim > 0
+
+
+def test_finite_limits_preserved():
+    tao = _simple_problem_tao()
+    p = TaoOptimizationProblem(tao)
+    assert p.variables[0].low_lim == -5.0
+    assert p.variables[0].high_lim == 5.0
+
+
+def test_x0_matches_model_values():
+    tao = _simple_problem_tao()
+    p = TaoOptimizationProblem(tao)
+    np.testing.assert_array_equal(p.x0, np.array([0.5, -0.3]))
+
+
+def test_x0_returns_copy_not_reference():
+    """Mutating the returned x0 must not affect the problem's internal state."""
+    tao = _simple_problem_tao()
+    p = TaoOptimizationProblem(tao)
+    x = p.x0
+    x[0] = 999.0
+    np.testing.assert_array_equal(p.x0, np.array([0.5, -0.3]))
+
+
+def test_bounds_and_bounds_array_shapes():
+    tao = _simple_problem_tao()
+    p = TaoOptimizationProblem(tao)
+    assert p.bounds == [(-5.0, 5.0), (-math.inf, math.inf)]
+    lb, ub = p.bounds_array
+    assert lb.shape == (2,) and ub.shape == (2,)
+    np.testing.assert_array_equal(lb, [-5.0, -math.inf])
+    np.testing.assert_array_equal(ub, [5.0, math.inf])
+
+
+def test_weights_vector():
+    tao = _simple_problem_tao()
+    p = TaoOptimizationProblem(tao)
+    np.testing.assert_array_equal(p.weights, [10.0, 100.0])
+
+
+def test_variable_names_order_stable():
+    tao = _simple_problem_tao()
+    p = TaoOptimizationProblem(tao)
+    assert p.variable_names == ["quad[1]", "quad[2]"]
+
+
+def test_multiple_v1_groups_are_all_enumerated():
+    tao = _simple_problem_tao()
+    tao.var_general_rows.append({"name": "bend", "line": "", "lbound": 1, "ubound": 1})
+    tao.var_v_array_rows["bend"] = [
+        {
+            "ix_v1": 1,
+            "var_attrib_name": "angle",
+            "meas_value": 0.0,
+            "model_value": 0.05,
+            "design_value": 0.05,
+            "useit_opt": True,
+            "good_user": True,
+            "weight": 0.0,
+        }
+    ]
+    tao.var_detail["bend[1]"] = _make_var_detail(
+        0.05, -math.inf, math.inf, ele_name="B1", attrib_name="angle"
+    )
+    p = TaoOptimizationProblem(tao)
+    assert [v.v1_name for v in p.variables] == ["quad", "quad", "bend"]
+    assert p.n_var == 3
+
+
+def test_multiple_d1_and_d2_groups_enumerated():
+    tao = _simple_problem_tao()
+    tao.d1_arrays["twiss"].append({"name": "max"})
+    tao.d_arrays[("twiss", "max")] = [
+        {
+            "ix_d1": 1,
+            "data_type": "beta.a",
+            "merit_type": "max",
+            "ele_ref_name": "",
+            "ele_start_name": "Q1",
+            "ele_name": "END",
+            "meas_value": 100.0,
+            "model_value": 20.0,
+            "design_value": 20.0,
+            "useit_opt": True,
+            "useit_plot": True,
+            "good_user": True,
+            "weight": 5.0,
+            "exists": True,
+        }
+    ]
+    p = TaoOptimizationProblem(tao)
+    assert p.n_data == 3
+    assert {d.d1_name for d in p.datums} == {"end", "max"}
+
+
+# ---- warnings ----------------------------------------------------------
+
+
+def test_warns_when_no_active_variables(caplog):
+    tao = _simple_problem_tao()
+    for row in tao.var_v_array_rows["quad"]:
+        row["useit_opt"] = False
+    with caplog.at_level("WARNING", logger="pytao.optimize.problem"):
+        TaoOptimizationProblem(tao)
+    assert any("no active variables" in rec.message for rec in caplog.records)
+
+
+def test_warns_when_no_active_datums(caplog):
+    tao = _simple_problem_tao()
+    for row in tao.d_arrays[("twiss", "end")]:
+        row["useit_opt"] = False
+    with caplog.at_level("WARNING", logger="pytao.optimize.problem"):
+        TaoOptimizationProblem(tao)
+    assert any("no active datums" in rec.message for rec in caplog.records)
+
+
+# ---- weight validation -------------------------------------------------
+
+
+def test_negative_datum_weight_is_rejected():
+    tao = _simple_problem_tao()
+    tao.d_arrays[("twiss", "end")][0]["weight"] = -1.0
+    with pytest.raises(ValueError, match="negative weight"):
+        TaoOptimizationProblem(tao)
+
+
+def test_negative_variable_weight_is_rejected():
+    tao = _simple_problem_tao()
+    tao.var_detail["quad[1]"]["weight"] = -2.0
+    with pytest.raises(ValueError, match="negative weight"):
+        TaoOptimizationProblem(tao)
+
+
+def test_zero_weight_is_accepted():
+    tao = _simple_problem_tao()
+    # Default weights are 0.0 on variables; make sure that's fine.
+    p = TaoOptimizationProblem(tao)
+    assert p.n_var == 2
+
+
+# ---- _finite_limit low-level sanity -----------------------------------
+
+
+def test_finite_limit_preserves_within_threshold():
+    assert _finite_limit(5.0, -1) == 5.0
+    assert _finite_limit(-5.0, -1) == -5.0
+    assert _finite_limit(1e19, 1) == pytest.approx(1e19)
+
+
+def test_finite_limit_translates_sentinels_to_inf():
+    assert math.isinf(_finite_limit(-1e30, -1)) and _finite_limit(-1e30, -1) < 0
+    assert math.isinf(_finite_limit(1e30, 1)) and _finite_limit(1e30, 1) > 0
+
+
+# ---- dataclass immutability -------------------------------------------
+
+
+def test_variable_info_is_frozen():
+    v = VariableInfo(
+        name="q[1]",
+        v1_name="q",
+        index=1,
+        initial_value=0.0,
+        low_lim=-1.0,
+        high_lim=1.0,
+        step=1e-4,
+        weight=0.0,
+        merit_type="target",
+        ele_name="Q1",
+        attrib_name="k1",
+    )
+    with pytest.raises(Exception):  # FrozenInstanceError
+        v.initial_value = 1.0  # type: ignore[misc]
+
+
+def test_datum_info_is_frozen():
+    d = DatumInfo(
+        name="d.end[1]",
+        d2_name="d",
+        d1_name="end",
+        ix_d1=1,
+        data_type="x",
+        merit_type="target",
+        meas_value=0.0,
+        model_value=0.0,
+        design_value=0.0,
+        weight=1.0,
+    )
+    with pytest.raises(Exception):
+        d.weight = 2.0  # type: ignore[misc]

--- a/pytao/tests/test_optimize_problem.py
+++ b/pytao/tests/test_optimize_problem.py
@@ -30,8 +30,13 @@ class FakeTao:
     var_v_array_rows: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
     var_detail: dict[str, dict[str, Any]] = field(default_factory=dict)
     d2_names: list[str] = field(default_factory=list)
+    d2_names_by_universe: dict[int, list[str]] = field(default_factory=dict)
     d1_arrays: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
     d_arrays: dict[tuple[str, str], list[dict[str, Any]]] = field(default_factory=dict)
+    d_arrays_by_universe: dict[tuple[int, str, str], list[dict[str, Any]]] = field(
+        default_factory=dict
+    )
+    default_universe: int = 1
 
     def var_general(self, *, raises: bool = True) -> list[dict[str, Any]]:  # noqa: ARG002
         return list(self.var_general_rows)
@@ -43,6 +48,8 @@ class FakeTao:
         return dict(self.var_detail[var])
 
     def data_d2_array(self, ix_uni: str = "", *, raises: bool = True):  # noqa: ARG002
+        if ix_uni and int(ix_uni) in self.d2_names_by_universe:
+            return list(self.d2_names_by_universe[int(ix_uni)])
         return list(self.d2_names)
 
     def data_d1_array(self, d2_datum: str, *, raises: bool = True):  # noqa: ARG002
@@ -58,7 +65,14 @@ class FakeTao:
         ix_uni: str = "",  # noqa: ARG002
         raises: bool = True,  # noqa: ARG002
     ):
+        if ix_uni:
+            key = (int(ix_uni), d2_name, d1_name)
+            if key in self.d_arrays_by_universe:
+                return list(self.d_arrays_by_universe[key])
         return list(self.d_arrays.get((d2_name, d1_name), []))
+
+    def tao_global(self, *, raises: bool = True) -> dict[str, Any]:  # noqa: ARG002
+        return {"default_universe": self.default_universe}
 
 
 def _make_var_detail(
@@ -404,3 +418,93 @@ def test_datum_info_is_frozen():
     )
     with pytest.raises(Exception):
         d.weight = 2.0  # type: ignore[misc]
+
+
+# ---- read-only snapshot contract ---------------------------------------
+
+
+def test_variables_is_immutable_tuple():
+    tao = _simple_problem_tao()
+    p = TaoOptimizationProblem(tao)
+    assert isinstance(p.variables, tuple)
+    with pytest.raises(AttributeError):
+        p.variables.append(p.variables[0])  # type: ignore[attr-defined]
+
+
+def test_datums_is_immutable_tuple():
+    tao = _simple_problem_tao()
+    p = TaoOptimizationProblem(tao)
+    assert isinstance(p.datums, tuple)
+    with pytest.raises(AttributeError):
+        p.datums.append(p.datums[0])  # type: ignore[attr-defined]
+
+
+# ---- universe selection -----------------------------------------------
+
+
+def test_universe_defaults_to_live_tao_global():
+    """When universe=None, snapshot pins to Tao's live default_universe."""
+    tao = _simple_problem_tao()
+    tao.default_universe = 3
+    # Put the only datum under universe 3 specifically; universe 1 has none.
+    tao.d2_names_by_universe = {3: ["twiss"]}
+    tao.d_arrays_by_universe = {(3, "twiss", "end"): tao.d_arrays[("twiss", "end")]}
+    tao.d_arrays = {}  # universe=1 sees nothing
+    p = TaoOptimizationProblem(tao)
+    assert p.universe == 3
+    assert p.n_data == 2
+
+
+def test_explicit_universe_overrides_default():
+    tao = _simple_problem_tao()
+    tao.default_universe = 1
+    # universe=2 sees a different set of datums.
+    tao.d2_names_by_universe = {2: ["twiss"]}
+    tao.d_arrays_by_universe = {
+        (
+            2,
+            "twiss",
+            "end",
+        ): [
+            {
+                "ix_d1": 1,
+                "data_type": "beta.a",
+                "merit_type": "target",
+                "ele_ref_name": "",
+                "ele_start_name": "",
+                "ele_name": "END",
+                "meas_value": 5.0,
+                "model_value": 4.0,
+                "design_value": 4.0,
+                "useit_opt": True,
+                "useit_plot": True,
+                "good_user": True,
+                "weight": 1.0,
+                "exists": True,
+            }
+        ]
+    }
+    p = TaoOptimizationProblem(tao, universe=2)
+    assert p.universe == 2
+    assert p.n_data == 1
+    assert p.datums[0].meas_value == 5.0
+
+
+def test_universe_falls_back_when_tao_global_missing(caplog):
+    """A Tao-like object without tao_global() falls back to universe=1."""
+
+    class MinimalFakeTao(FakeTao):
+        tao_global = None  # type: ignore[assignment]
+
+    tao = MinimalFakeTao()
+    simple = _simple_problem_tao()
+    tao.var_general_rows = simple.var_general_rows
+    tao.var_v_array_rows = simple.var_v_array_rows
+    tao.var_detail = simple.var_detail
+    tao.d2_names = simple.d2_names
+    tao.d1_arrays = simple.d1_arrays
+    tao.d_arrays = simple.d_arrays
+    with caplog.at_level("WARNING", logger="pytao.optimize.problem"):
+        p = TaoOptimizationProblem(tao)
+    assert p.universe == 1
+    assert any("does not expose tao_global" in rec.message for rec in caplog.records)

--- a/pytao/tests/test_optimize_problem.py
+++ b/pytao/tests/test_optimize_problem.py
@@ -191,7 +191,7 @@ def _simple_problem_tao() -> FakeTao:
 
 def test_problem_extracts_only_active_variables():
     tao = _simple_problem_tao()
-    p = TaoOptimizationProblem(tao)
+    p = TaoOptimizationProblem.from_tao(tao)
     assert p.n_var == 2
     assert [v.name for v in p.variables] == ["quad[1]", "quad[2]"]
     assert p.variables[0].ele_name == "Q1"
@@ -201,7 +201,7 @@ def test_problem_extracts_only_active_variables():
 def test_problem_extracts_only_active_datums():
     tao = _simple_problem_tao()
     tao.d_arrays[("twiss", "end")][1]["useit_opt"] = False
-    p = TaoOptimizationProblem(tao)
+    p = TaoOptimizationProblem.from_tao(tao)
     assert p.n_data == 1
     assert p.datums[0].name == "twiss.end[1]"
 
@@ -209,7 +209,7 @@ def test_problem_extracts_only_active_datums():
 def test_variable_preserves_merit_and_attribute_metadata():
     tao = _simple_problem_tao()
     tao.var_detail["quad[1]"]["merit_type"] = "limit"
-    p = TaoOptimizationProblem(tao)
+    p = TaoOptimizationProblem.from_tao(tao)
     assert p.variables[0].merit_type == "limit"
     assert p.variables[0].attrib_name == "k1"
     assert p.variables[0].step == pytest.approx(1e-4)
@@ -218,35 +218,35 @@ def test_variable_preserves_merit_and_attribute_metadata():
 def test_datum_preserves_merit_type_and_weight():
     tao = _simple_problem_tao()
     tao.d_arrays[("twiss", "end")][0]["merit_type"] = "max"
-    p = TaoOptimizationProblem(tao)
+    p = TaoOptimizationProblem.from_tao(tao)
     assert p.datums[0].merit_type == "max"
     assert p.datums[0].weight == 10.0
 
 
 def test_unbounded_sentinels_become_inf():
     tao = _simple_problem_tao()
-    p = TaoOptimizationProblem(tao)
+    p = TaoOptimizationProblem.from_tao(tao)
     assert math.isinf(p.variables[1].low_lim) and p.variables[1].low_lim < 0
     assert math.isinf(p.variables[1].high_lim) and p.variables[1].high_lim > 0
 
 
 def test_finite_limits_preserved():
     tao = _simple_problem_tao()
-    p = TaoOptimizationProblem(tao)
+    p = TaoOptimizationProblem.from_tao(tao)
     assert p.variables[0].low_lim == -5.0
     assert p.variables[0].high_lim == 5.0
 
 
 def test_x0_matches_model_values():
     tao = _simple_problem_tao()
-    p = TaoOptimizationProblem(tao)
+    p = TaoOptimizationProblem.from_tao(tao)
     np.testing.assert_array_equal(p.x0, np.array([0.5, -0.3]))
 
 
 def test_x0_returns_copy_not_reference():
     """Mutating the returned x0 must not affect the problem's internal state."""
     tao = _simple_problem_tao()
-    p = TaoOptimizationProblem(tao)
+    p = TaoOptimizationProblem.from_tao(tao)
     x = p.x0
     x[0] = 999.0
     np.testing.assert_array_equal(p.x0, np.array([0.5, -0.3]))
@@ -254,7 +254,7 @@ def test_x0_returns_copy_not_reference():
 
 def test_bounds_and_bounds_array_shapes():
     tao = _simple_problem_tao()
-    p = TaoOptimizationProblem(tao)
+    p = TaoOptimizationProblem.from_tao(tao)
     assert p.bounds == [(-5.0, 5.0), (-math.inf, math.inf)]
     lb, ub = p.bounds_array
     assert lb.shape == (2,) and ub.shape == (2,)
@@ -264,13 +264,13 @@ def test_bounds_and_bounds_array_shapes():
 
 def test_weights_vector():
     tao = _simple_problem_tao()
-    p = TaoOptimizationProblem(tao)
+    p = TaoOptimizationProblem.from_tao(tao)
     np.testing.assert_array_equal(p.weights, [10.0, 100.0])
 
 
 def test_variable_names_order_stable():
     tao = _simple_problem_tao()
-    p = TaoOptimizationProblem(tao)
+    p = TaoOptimizationProblem.from_tao(tao)
     assert p.variable_names == ["quad[1]", "quad[2]"]
 
 
@@ -292,7 +292,7 @@ def test_multiple_v1_groups_are_all_enumerated():
     tao.var_detail["bend[1]"] = _make_var_detail(
         0.05, -math.inf, math.inf, ele_name="B1", attrib_name="angle"
     )
-    p = TaoOptimizationProblem(tao)
+    p = TaoOptimizationProblem.from_tao(tao)
     assert [v.v1_name for v in p.variables] == ["quad", "quad", "bend"]
     assert p.n_var == 3
 
@@ -318,7 +318,7 @@ def test_multiple_d1_and_d2_groups_enumerated():
             "exists": True,
         }
     ]
-    p = TaoOptimizationProblem(tao)
+    p = TaoOptimizationProblem.from_tao(tao)
     assert p.n_data == 3
     assert {d.d1_name for d in p.datums} == {"end", "max"}
 
@@ -331,7 +331,7 @@ def test_warns_when_no_active_variables(caplog):
     for row in tao.var_v_array_rows["quad"]:
         row["useit_opt"] = False
     with caplog.at_level("WARNING", logger="pytao.optimize.problem"):
-        TaoOptimizationProblem(tao)
+        TaoOptimizationProblem.from_tao(tao)
     assert any("no active variables" in rec.message for rec in caplog.records)
 
 
@@ -340,7 +340,7 @@ def test_warns_when_no_active_datums(caplog):
     for row in tao.d_arrays[("twiss", "end")]:
         row["useit_opt"] = False
     with caplog.at_level("WARNING", logger="pytao.optimize.problem"):
-        TaoOptimizationProblem(tao)
+        TaoOptimizationProblem.from_tao(tao)
     assert any("no active datums" in rec.message for rec in caplog.records)
 
 
@@ -351,20 +351,20 @@ def test_negative_datum_weight_is_rejected():
     tao = _simple_problem_tao()
     tao.d_arrays[("twiss", "end")][0]["weight"] = -1.0
     with pytest.raises(ValueError, match="negative weight"):
-        TaoOptimizationProblem(tao)
+        TaoOptimizationProblem.from_tao(tao)
 
 
 def test_negative_variable_weight_is_rejected():
     tao = _simple_problem_tao()
     tao.var_detail["quad[1]"]["weight"] = -2.0
     with pytest.raises(ValueError, match="negative weight"):
-        TaoOptimizationProblem(tao)
+        TaoOptimizationProblem.from_tao(tao)
 
 
 def test_zero_weight_is_accepted():
     tao = _simple_problem_tao()
     # Default weights are 0.0 on variables; make sure that's fine.
-    p = TaoOptimizationProblem(tao)
+    p = TaoOptimizationProblem.from_tao(tao)
     assert p.n_var == 2
 
 
@@ -425,7 +425,7 @@ def test_datum_info_is_frozen():
 
 def test_variables_is_immutable_tuple():
     tao = _simple_problem_tao()
-    p = TaoOptimizationProblem(tao)
+    p = TaoOptimizationProblem.from_tao(tao)
     assert isinstance(p.variables, tuple)
     with pytest.raises(AttributeError):
         p.variables.append(p.variables[0])  # type: ignore[attr-defined]
@@ -433,7 +433,7 @@ def test_variables_is_immutable_tuple():
 
 def test_datums_is_immutable_tuple():
     tao = _simple_problem_tao()
-    p = TaoOptimizationProblem(tao)
+    p = TaoOptimizationProblem.from_tao(tao)
     assert isinstance(p.datums, tuple)
     with pytest.raises(AttributeError):
         p.datums.append(p.datums[0])  # type: ignore[attr-defined]
@@ -450,7 +450,7 @@ def test_universe_defaults_to_live_tao_global():
     tao.d2_names_by_universe = {3: ["twiss"]}
     tao.d_arrays_by_universe = {(3, "twiss", "end"): tao.d_arrays[("twiss", "end")]}
     tao.d_arrays = {}  # universe=1 sees nothing
-    p = TaoOptimizationProblem(tao)
+    p = TaoOptimizationProblem.from_tao(tao)
     assert p.universe == 3
     assert p.n_data == 2
 
@@ -484,7 +484,7 @@ def test_explicit_universe_overrides_default():
             }
         ]
     }
-    p = TaoOptimizationProblem(tao, universe=2)
+    p = TaoOptimizationProblem.from_tao(tao, universe=2)
     assert p.universe == 2
     assert p.n_data == 1
     assert p.datums[0].meas_value == 5.0
@@ -505,6 +505,6 @@ def test_universe_falls_back_when_tao_global_missing(caplog):
     tao.d1_arrays = simple.d1_arrays
     tao.d_arrays = simple.d_arrays
     with caplog.at_level("WARNING", logger="pytao.optimize.problem"):
-        p = TaoOptimizationProblem(tao)
+        p = TaoOptimizationProblem.from_tao(tao)
     assert p.universe == 1
     assert any("does not expose tao_global" in rec.message for rec in caplog.records)


### PR DESCRIPTION
A new subpackage that reads a live `Tao` instance and reports its
optimization setup as structured Python objects — the variables and datums
Tao would use for optimization, plus their bounds, weights, and merit types.

```python
from pytao import Tao
from pytao.optimize import TaoOptimizationProblem

tao = Tao(init_file="tao.init", noplot=True)
problem = TaoOptimizationProblem(tao)

problem.n_var           # number of active optimization variables
problem.n_data          # number of active datums
problem.x0              # initial variable vector
problem.bounds          # list of (low, high) tuples; ±inf allowed
problem.weights         # per-datum merit weights
problem.variables       # list[VariableInfo]
problem.datums          # list[DatumInfo]
```

Highlights:

- Filters to `useit_opt = True` entries, i.e. what Tao itself would pass to
  its internal optimizers.
- Translates Tao's ±1e30 "no limit" sentinels to ±inf so downstream
  optimizer libraries see standard unbounded-side semantics.
- Rejects negative weights at construction — catches a class of user errors
  at the boundary rather than silently producing NaNs later.
- Multi-universe aware: with no argument, `TaoOptimizationProblem` reads
  Tao's live `s%global%default_universe`; pass `universe=N` to pin the
  snapshot to a specific universe.
- `problem.variables` and `problem.datums` are immutable tuples of frozen
  dataclasses, so the snapshot cannot drift out of sync with `x0`,
  `bounds`, and `weights`.

This is the first slice of a larger Python-driven optimization workflow.
Follow-up releases will add merit evaluation, Jacobian access, and SciPy
adapters (`run_scipy_minimize`, `run_scipy_least_squares`). See the
[optimization guide](optimize.md) for a walkthrough.

### Disclaimer

This is fully written by Claude