### PR TITLE
BLD: fix case of openpmd-beamphysics

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - matplotlib
   - numpy
   - numpydoc
-  - openPMD-beamphysics >=0.14.1
+  - openpmd-beamphysics >=0.14.1
   - orjson
   - ormsgpack
   - pydantic >=2.12.5


### PR DESCRIPTION
The case of the dependency randomly started causing issues with the Bmad-ecosystem environment build.

Thanks to @tangkong for helping find this! The dependency being cached on my system meant I couldn't reproduce it locally.

Upstream PR: https://github.com/bmad-sim/bmad-ecosystem/pull/2034