### PR TITLE
FIX: load_combs_from_lattice_data may have raw ndarrays

### DIFF
--- a/pytao/model/base.py
+++ b/pytao/model/base.py
@@ -28,7 +28,7 @@ from beamphysics.units import pmd_unit
 from pydantic.fields import FieldInfo
 from typing_extensions import Self, override
 
-from .types import ArgumentType
+from .types import ArgumentType, _PydanticNDArray
 
 from rich.pretty import pretty_repr
 
@@ -734,7 +734,7 @@ def dump_model(
     return data
 
 
-_MSGPACK_NDARRAY_MARKER = "__ndarray__"
+_MSGPACK_NDARRAY_MARKER = _PydanticNDArray._MSGPACK_MARKER
 
 
 def _msgpack_default(obj: Any) -> Any:
@@ -766,7 +766,8 @@ def _msgpack_default(obj: Any) -> Any:
 
 
 def _msgpack_restore_ndarrays(obj: Any) -> Any:
-    """Restore numpy arrays from ``__ndarray__`` marker dicts, in-place.
+    """
+    Restore numpy arrays from ``__ndarray__`` marker dicts, in-place.
 
     Walks the deserialized msgpack structure and replaces marker dicts
     with actual numpy arrays.  Modifies containers in-place to avoid

--- a/pytao/model/ele/comb.py
+++ b/pytao/model/ele/comb.py
@@ -8,7 +8,7 @@ from beamphysics.species import mass_of
 from typing_extensions import Self
 
 from ..base import ArchiveFormat, TaoModel, load_model_data
-from ..types import NDArray, empty_ndarray
+from ..types import NDArray, deserialize_ndarray, empty_ndarray
 
 if typing.TYPE_CHECKING:
     from pytao import Tao
@@ -285,6 +285,17 @@ class Comb(TaoModel, extra="allow"):
     def query(self, tao: Tao) -> Self:
         return self.from_tao(tao)
 
+    def sort_by_s(self) -> Comb:
+        """Sort array data by `s` position."""
+        res = Comb()
+        order = np.argsort(self.s)
+        for attr in _comb_array_attrs:
+            value = getattr(self, attr)
+
+            if value.size:
+                setattr(res, attr, np.asarray(value)[order])
+        return res
+
     @classmethod
     def from_tao(
         cls: type[Self], tao: Tao, *, check_ds_save: bool = True, ix_branch: int = 0, **kwargs
@@ -345,41 +356,84 @@ class Comb(TaoModel, extra="allow"):
         return type(self)(**data)
 
 
-def combine_combs(combs: typing.Sequence[Comb]) -> Comb:
+_comb_array_attrs = set(Comb.model_fields) - {"command_args"}
+
+
+def combine_combs(combs: typing.Sequence[Comb], sort: bool = True) -> Comb:
     """Combine the given combs into a single one."""
-    attrs = set(Comb.model_fields) - {"command_args"}
     res = Comb()
 
-    for attr in attrs:
+    for attr in _comb_array_attrs:
         parts = [getattr(comb, attr) for comb in combs]
-        setattr(res, attr, np.concat(parts))
+        if parts:
+            setattr(res, attr, np.concat(parts))
 
-    order = np.argsort(res.s)
-    for attr in attrs:
-        value = getattr(res, attr)
-
-        if value.size:
-            setattr(res, attr, np.asarray(value)[order])
-    return res
+    return res.sort_by_s() if sort else res
 
 
-def load_combs_from_lattice_data(lat_data) -> Comb:
+def load_combs_from_lattice_data(lat_data, sort: bool = False) -> Comb:
+    """
+    Load comb data from raw lattice data.
+
+    This can be used to speed up loading only comb data from an archive.
+
+    Parameters
+    ----------
+    lat_data : dict
+        Raw Lattice model data.
+    sort : bool, optional
+        Sort comb data by s position. Defaults to True.
+
+    Returns
+    -------
+    Comb
+
+    Example
+    -------
+    >>> lattice_data = load_model_data(lattice_dump_fn, raw=True)
+    >>> comb = load_combs_from_lattice_data(lattice_data)
+    """
     comb_data = {}
     for ele in lat_data["elements"]:
         if "comb" in ele:
             for key, value in ele["comb"].items():
-                if isinstance(value, list):
+                if key in _comb_array_attrs:
+                    arr = deserialize_ndarray(value)
                     comb_data.setdefault(key, [])
-                    comb_data[key].extend(value)
-    return Comb(**comb_data)
+                    comb_data[key].extend(arr.tolist())
+    comb = Comb(**comb_data)
+    return comb.sort_by_s() if sort else comb
 
 
-def load_combs_from_lattice_file(fn: pathlib.Path, format: ArchiveFormat | None = None):
+def load_combs_from_lattice_file(
+    fn: pathlib.Path,
+    format: ArchiveFormat | None = None,
+    sort: bool = True,
+) -> Comb:
+    """
+    Load only comb data from a lattice file.
+
+    Parameters
+    ----------
+    fn : pathlib.Path
+        The Lattice filename dump to load from.
+    format : ArchiveFormat or None, optional
+        The format of the archive.
+    sort : bool, optional
+        Sort comb data by s position. Defaults to True.
+
+    Returns
+    -------
+    Comb
+    """
     data = load_model_data(fn, format=format)
 
     from .. import Lattice
 
     if isinstance(data, Lattice):
-        return combine_combs([ele.comb for ele in data.elements if ele.comb is not None])
+        return combine_combs(
+            [ele.comb for ele in data.elements if ele.comb is not None],
+            sort=sort,
+        )
     # Otherwise, just raw lattice data
-    return load_combs_from_lattice_data(data)
+    return load_combs_from_lattice_data(data, sort=sort)

--- a/pytao/model/types.py
+++ b/pytao/model/types.py
@@ -187,6 +187,10 @@ class _PydanticNDArray:
         raise ValueError(f"No conversion from {value!r} to numpy ndarray")
 
 
+def deserialize_ndarray(value: Any | np.ndarray | Sequence | dict):
+    return _PydanticNDArray._pydantic_validate(value, None)
+
+
 _zeros = np.zeros(0)
 
 

--- a/pytao/tests/ele/test_comb.py
+++ b/pytao/tests/ele/test_comb.py
@@ -8,8 +8,13 @@ import numpy as np
 import pytest
 
 from pytao import SubprocessTao
-from pytao.model.ele import Comb
-from pytao.model.ele.comb import combine_combs
+from pytao.model.base import _msgpack_default
+from pytao.model import Comb, Element, ElementHead, Lattice
+from pytao.model.ele.comb import (
+    combine_combs,
+    load_combs_from_lattice_data,
+    load_combs_from_lattice_file,
+)
 
 
 @pytest.fixture(scope="module")
@@ -72,6 +77,73 @@ def test_combine():
         charge_live=np.asarray([1, 2, 3, 4, 5, 6]),
         s=np.asarray([1, 2, 3, 4, 5, 6]),
     )
+    assert combined == expected
+
+
+def test_combine_empty():
+    a = Comb()
+    b = Comb()
+
+    combined = combine_combs([a, b])
+    expected = Comb()
+    assert combined == expected
+
+
+def test_load_from_lattice_data():
+    d1 = {
+        "elements": [
+            {
+                "comb": {"s": [4, 5, 6]},
+            },
+            {
+                "comb": {"s": _msgpack_default(np.asarray([1, 2, 3]))},
+            },
+            {
+                "comb": {"s": []},
+            },
+        ],
+    }
+
+    expected = Comb(s=np.asarray([4, 5, 6, 1, 2, 3]))
+    combined = load_combs_from_lattice_data(d1)
+    assert combined == expected
+
+    expected = Comb(s=np.asarray([1, 2, 3, 4, 5, 6]))
+    combined = load_combs_from_lattice_data(d1, sort=True)
+    assert combined == expected
+
+
+@pytest.mark.parametrize("format", ["msgpack", "json"])
+@pytest.mark.parametrize("exclude_defaults", [False, True])
+def test_load_from_lattice_file(
+    tmp_path: pathlib.Path, format: Literal["msgpack", "json"], exclude_defaults: bool
+):
+    lat = Lattice(
+        which="model",
+        elements=(
+            Element(
+                ele_id="0",
+                which="model",
+                head=ElementHead(key="BEGINNING"),
+                comb=Comb(s=np.asarray([4, 5, 6])),
+            ),
+            Element(
+                ele_id="1",
+                which="model",
+                head=ElementHead(key="PIPE"),
+                comb=Comb(s=np.asarray([1, 2, 3])),
+            ),
+        ),
+    )
+
+    lat.write(tmp_path, format=format, exclude_defaults=exclude_defaults)
+
+    expected = Comb(s=np.asarray([4, 5, 6, 1, 2, 3]))
+    combined = load_combs_from_lattice_file(tmp_path, format=format, sort=False)
+    assert combined == expected
+
+    expected = Comb(s=np.asarray([1, 2, 3, 4, 5, 6]))
+    combined = load_combs_from_lattice_file(tmp_path, format=format, sort=True)
     assert combined == expected
 
 


### PR DESCRIPTION
## Background

Raw lattice comb data now may have the serialized version of msgpack ndarray data in it after v1.0.4.
There were a couple holes in testing for this, leading to comb data potentially being skipped over (and even raising for empty comb data).

### Changes

* Fix the underlying issue and properly deserialize the raw comb data
* Add more tests to better ensure this won't break again
* Add `Comb.sort_by_s()` for convenience