### PR TITLE
FIX: reinflation of comb arrays when loading raw data

### DIFF
--- a/pytao/model/ele/comb.py
+++ b/pytao/model/ele/comb.py
@@ -398,7 +398,12 @@ def load_combs_from_lattice_data(lat_data, sort: bool = False) -> Comb:
         if "comb" in ele:
             for key, value in ele["comb"].items():
                 if key in _comb_array_attrs:
-                    arr = deserialize_ndarray(value)
+                    if isinstance(value, np.ndarray):
+                        arr = value
+                    else:
+                        arr = deserialize_ndarray(value)
+                        ele["comb"][key] = arr
+
                     comb_data.setdefault(key, [])
                     comb_data[key].extend(arr.tolist())
     comb = Comb(**comb_data)

--- a/pytao/model/ele/ele.py
+++ b/pytao/model/ele/ele.py
@@ -16,7 +16,7 @@ from ...util.parsers import Attr, parse_tao_python_data_with_units
 from .. import _generated as tao_classes
 from ..base import ArchiveFormat, TaoBaseModel, TaoModel
 from ..types import NDArray, _PydanticNDArray
-from .comb import Comb
+from .comb import Comb, _comb_array_attrs
 from .time_stats import _pytao_stats
 
 if TYPE_CHECKING:
@@ -2521,3 +2521,9 @@ def restore_raw_element_ndarrays(ele: dict) -> None:
                     ref_data["wmat"] = _PydanticNDArray._pydantic_validate(
                         ref_data["wmat"], None
                     )
+    comb = ele.get("comb")
+    if comb:
+        for key in _comb_array_attrs:
+            value = comb.get(key)
+            if value is not None:
+                comb[key] = _PydanticNDArray._pydantic_validate(value, None)

--- a/pytao/tests/ele/test_ele.py
+++ b/pytao/tests/ele/test_ele.py
@@ -647,6 +647,20 @@ def test_raw_already_ndarray():
     assert ele["mat6"]["vec0"] is vec
 
 
+def test_ndarray_in_comb():
+    vec = np.array([1.0, 2.0])
+    ele = {"comb": {"s": vec}}
+    restore_raw_element_ndarrays(ele)
+    assert ele["comb"]["s"] is vec
+
+
+def test_raw_ndarray_in_comb():
+    vec = np.array([1.0, 2.0])
+    ele = {"comb": {"s": _make_ndarray_dict(vec)}}
+    restore_raw_element_ndarrays(ele)
+    np.testing.assert_array_equal(ele["comb"]["s"], vec)
+
+
 class ArrHolder(TaoBaseModel):
     arr: NDArray
 


### PR DESCRIPTION
### Another comb PR

This is another minor one - reinflating comb ndarrays when users load raw msgpack data.

For context, this is not a typical code path, except for those who really are trying to get decent performance when loading large lattice data dumps. The difference can be significant enough to make these acrobatics worthwhile (on the order of a second or two, I believe, for large lattices).