### PR TITLE
FIX: multi-character super/subscripts

### DIFF
--- a/pytao/cli.py
+++ b/pytao/cli.py
@@ -143,6 +143,7 @@ def print_header(ipython: bool, startup_message: str, plot: str | None = "") -> 
 def init(argv, ipython: bool, exit_on_error=True):
     args = PytaoArgs.from_cli_args(argv[1:], exit_on_error=exit_on_error)
     args.pyplot = os.environ.get("PYTAO_PLOT", args.pyplot or "tao").lower()
+    args.plot = args.pyplot
 
     args = _get_implied_init_args(args)
     if not args.pyquiet:

--- a/pytao/plotting/pgplot.py
+++ b/pytao/plotting/pgplot.py
@@ -88,11 +88,19 @@ def mpl_string(value: str) -> str:
         d_pos = result.find(r"\\d")
         u_pos = result.find(r"\\u")
         if d_pos < u_pos:
+            # Subscript
+            modifier = "_"
             sx = result[d_pos : u_pos + 3]
-            result = result.replace(sx, "_" + sx[3:-3])
         else:
+            # Superscript
+            modifier = "^"
             sx = result[u_pos : d_pos + 3]
-            result = result.replace(sx, "^" + sx[3:-3])
+
+        subscript = sx[3:-3]  # or superscript
+        if len(subscript) > 1:
+            result = result.replace(sx, modifier + "{" + subscript + "}")
+        else:
+            result = result.replace(sx, f"{modifier}{subscript}")
 
     # TODO this is far from performant, but this is unlikely to be called
     # frequently so I'm leaving it for now


### PR DESCRIPTION
## Background

`E_{tot}` was not being rendered with proper LaTeX, leaving just the first character as a sub/superscript and not the remainder.

The `--pyplot` argument for the `pytao` CLI entrypoint was also not propagating properly. This resolves that as well.

### Before

<img height="200" alt="image" src="https://github.com/user-attachments/assets/1675afc1-ebb8-45b0-afdf-18ee53d243a5" />

### After: Matplotlib
<img  height="200" alt="image" src="https://github.com/user-attachments/assets/2aef061f-3eee-4972-8931-888f7acf8230" />


### After: Bokeh

<img height="300" alt="image" src="https://github.com/user-attachments/assets/67708a76-edbb-4272-8205-ebfbed82653d" />
