### PR TITLE
WIP/ENH: optional "modern" layout

### DIFF
--- a/docs/examples/plot-modern-layout.ipynb
+++ b/docs/examples/plot-modern-layout.ipynb
@@ -1,0 +1,227 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Modern lattice layout\n",
+    "\n",
+    "PyTao ships an opt-in replacement for the default `lat_layout` graph, called the **modern layout**.\n",
+    "It draws each element from a Python-side `ModernLayoutConfig` that classifies elements by `key`\n",
+    "and `name`, then renders the result with either backend (Matplotlib or Bokeh)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Tao setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%config InlineBackend.figure_format = \"retina\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"BOKEH_ALLOW_WS_ORIGIN\"] = \"*\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from pytao import Tao\n",
+    "from pytao.plotting import ModernLayoutConfig"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tao = Tao(init_file=\"$ACC_ROOT_DIR/bmad-doc/tao_examples/cbeta_ffag/tao.init\", plot=\"bokeh\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Enable the modern layout\n",
+    "\n",
+    "Set `layout_style` on whichever graph manager(s) you want. Set it to `None` to revert."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cfg = ModernLayoutConfig.default()\n",
+    "\n",
+    "tao.bokeh.layout_style = cfg\n",
+    "tao.matplotlib.layout_style = cfg"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To make the modern layout the default for every new manager:\n",
+    "\n",
+    "```python\n",
+    "tao.bokeh.configure(layout_style=cfg)\n",
+    "tao.matplotlib.configure(layout_style=cfg)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Bokeh: beta on top, modern layout below"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tao.plot(\"beta\", include_layout=True, width=900, xlim=(0, 5), backend=\"bokeh\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Matplotlib: same plot, same modern layout"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tao.plot(\"beta\", include_layout=True, figsize=(9, 4), backend=\"mpl\", xlim=(0, 5))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## BPM naming\n",
+    "\n",
+    "Some lattices use the `MARKER` key for BPMs (e.g. `FA.BPM01`). By default, any `MARKER`\n",
+    "whose name contains `BPM` renders with the BPM style; other markers are skipped.\n",
+    "\n",
+    "For a different convention, add a rule:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pytao.plotting import ClassifyRule\n",
+    "\n",
+    "tao.bokeh.layout_style = cfg.with_overrides(\n",
+    "    rules=[\n",
+    "        *cfg.rules,\n",
+    "        ClassifyRule(key_pattern=r\"^MARKER$\", name_pattern=r\"PROBE\", style=\"BPM\"),\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Customize colors and sizes\n",
+    "\n",
+    "`with_overrides` returns a copy; `styles` accepts partial merges."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "highlighted = cfg.with_overrides(\n",
+    "    styles={\n",
+    "        \"KICKER\": {\"color\": \"#FF1493\", \"height\": 36},\n",
+    "        \"QUADRUPOLE\": {\"color\": \"#1E90FF\"},\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "tao.bokeh.layout_style = highlighted\n",
+    "tao.plot(\"beta\", include_layout=True, width=900, backend=\"bokeh\", xlim=(0, 5))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Revert\n",
+    "\n",
+    "Setting `layout_style = None` restores the default Tao-driven layout."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# tao.bokeh.layout_style = None\n",
+    "# tao.matplotlib.layout_style = None\n",
+    "\n",
+    "# tao.plot(\"beta\", include_layout=True, figsize=(9, 4), backend=\"mpl\")\n",
+    "# NOTE: This is commented out, just in case you ran the whole notebook."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "kyber",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ nav:
       - examples/elements.ipynb
       - examples/config.ipynb
       - examples/plot-matplotlib.ipynb
+      - examples/plot-modern-layout.ipynb
       - examples/plot-bokeh.ipynb
       - examples/plot-bokeh-vars.ipynb
       - examples/plot-bokeh-particles.ipynb

--- a/pytao/model/ele/ele.py
+++ b/pytao/model/ele/ele.py
@@ -1826,8 +1826,9 @@ class Element(TaoBaseModel, extra="forbid"):
     def __repr_args__(self) -> Iterable[tuple[str | None, Any]]:
         for key, value in super().__repr_args__():
             if key == "attrs":
-                # Swap out 'attrs' with 'attribs' for just the repr
-                yield "attribs", self.attribs
+                if value is not None:
+                    # Swap out 'attrs' with 'attribs' for just the repr
+                    yield "attribs", self.attribs
             else:
                 yield key, value
 

--- a/pytao/plotting/__init__.py
+++ b/pytao/plotting/__init__.py
@@ -1,4 +1,12 @@
 from .curves import TaoCurveSettings
+from .modern_layout import (
+    ClassifyRule,
+    ElementStyle,
+    LayoutData,
+    LayoutSection,
+    ModernLatticeLayoutGraph,
+    ModernLayoutConfig,
+)
 from .mpl import MatplotlibGraphManager
 from .plot import GraphManager
 from .settings import (
@@ -11,8 +19,14 @@ from .settings import (
 from .util import select_graph_manager_class
 
 __all__ = [
+    "ClassifyRule",
+    "ElementStyle",
     "GraphManager",
+    "LayoutData",
+    "LayoutSection",
     "MatplotlibGraphManager",
+    "ModernLatticeLayoutGraph",
+    "ModernLayoutConfig",
     "QuickPlotPoint",
     "QuickPlotRectangle",
     "TaoAxisSettings",

--- a/pytao/plotting/bokeh.py
+++ b/pytao/plotting/bokeh.py
@@ -38,6 +38,14 @@ from bokeh.plotting import figure
 from pydantic.dataclasses import dataclass
 from typing_extensions import NotRequired, TypedDict
 
+from pytao.plotting.modern_layout import (
+    BoxData,
+    MarkerData,
+    ModernLatticeLayoutGraph,
+    ModernLayoutConfig,
+    StemData,
+)
+
 from ..core import AnyPath, TaoCommandError
 from . import floor_plan_shapes, pgplot, util
 from .curves import CurveIndexToCurve, PlotCurveLine, PlotCurveSymbols, TaoCurveSettings
@@ -71,6 +79,7 @@ from .util import Limit, OptionalLimit, fix_grid_limits
 
 if typing.TYPE_CHECKING:
     from .. import Tao
+    from .modern_layout import LayoutSection
 
 
 logger = logging.getLogger(__name__)
@@ -112,6 +121,7 @@ class _Defaults:
     show_sliders: bool = True
     line_width_scale: float = 0.5
     floor_line_width_scale: float = 0.5
+    layout_style: ModernLayoutConfig | None = None
 
     @classmethod
     def get_size_for_class(
@@ -123,9 +133,13 @@ class _Defaults:
         default = {
             BokehBasicGraph: (cls.width, cls.height),
             BokehLatticeLayoutGraph: (cls.width, cls.layout_height),
+            BokehModernLatticeLayoutGraph: (cls.width, cls.layout_height),
             BokehFloorPlanGraph: (cls.width, cls.height),
         }[typ]
         return (user_width or default[0], user_height or default[1])
+
+
+_UNSET = object()
 
 
 def set_defaults(
@@ -148,6 +162,7 @@ def set_defaults(
     show_sliders: bool | None = None,
     line_width_scale: float | None = None,
     floor_line_width_scale: float | None = None,
+    layout_style: ModernLayoutConfig | None | object = _UNSET,
 ):
     """
     Change defaults used for Bokeh plots.
@@ -191,6 +206,12 @@ def set_defaults(
         Plot line width scaling factor applied to Tao's line width.
     floor_line_width_scale : float, default=0.5
         Floor plan line width scaling factor applied to Tao's line width.
+    layout_style : ModernLayoutConfig or None, optional
+        Modern-layout config used for ``lat_layout`` graphs.  When a
+        ``ModernLayoutConfig`` is supplied, every new ``GraphManager`` (and
+        any existing manager that hasn't pinned a per-instance value) will
+        render layouts via :class:`ModernLatticeLayoutGraph`. Pass ``None``
+        to revert to the Tao-driven lattice layout.
     """
 
     if width is not None:
@@ -231,6 +252,8 @@ def set_defaults(
         _Defaults.line_width_scale = float(line_width_scale)
     if floor_line_width_scale is not None:
         _Defaults.floor_line_width_scale = float(floor_line_width_scale)
+    if layout_style is not _UNSET:
+        _Defaults.layout_style = typing.cast("ModernLayoutConfig | None", layout_style)
     return {
         key: value
         for key, value in vars(_Defaults).items()
@@ -951,6 +974,227 @@ class BokehLatticeLayoutGraph(BokehGraphBase[LatticeLayoutGraph]):
         return fig
 
 
+class BokehModernLatticeLayoutGraph(BokehGraphBase[ModernLatticeLayoutGraph]):
+    """Bokeh adapter for ``ModernLatticeLayoutGraph``."""
+
+    graph_type: ClassVar[str] = "modern_lat_layout"
+    graph: ModernLatticeLayoutGraph
+
+    def __init__(
+        self,
+        manager: GraphManager,
+        graph: ModernLatticeLayoutGraph,
+        sizing_mode: SizingModeType = "inherit",
+        width: int | None = None,
+        height: int | None = None,
+        aspect_ratio: float | None = None,
+    ) -> None:
+        super().__init__(
+            manager=manager,
+            graph=graph,
+            sizing_mode=sizing_mode,
+            aspect_ratio=aspect_ratio,
+            width=width,
+            height=height,
+        )
+
+    def update_plot(
+        self,
+        fig: figure,
+        *,
+        widgets: list[bokeh.models.Widget] | None = None,
+        tao=None,
+    ) -> None:
+        if tao is None:
+            return
+
+    def create_figure(
+        self,
+        *,
+        tools: str | None = None,
+        toolbar_location: str = "above",
+    ) -> figure:
+        if tools is None:
+            tools = _Defaults.lattice_layout_tools
+
+        add_named_hover = isinstance(tools, str) and "hover" in tools.split(",")
+        if add_named_hover:
+            tools = ",".join(t for t in tools.split(",") if t != "hover")
+
+        graph = self.graph
+        fig = figure(
+            title=f"Lattice layout - {graph.data.branch_name}",
+            x_axis_label="s (m)",
+            toolbar_location=toolbar_location,
+            tools=tools,
+            aspect_ratio=self.aspect_ratio,
+            sizing_mode=self.sizing_mode,
+        )
+
+        box_zoom = get_tool_from_figure(fig, bokeh.models.BoxZoomTool)
+        if box_zoom is not None:
+            box_zoom.match_aspect = False
+
+        fig.yaxis.visible = False
+        fig.ygrid.visible = False
+
+        fig.line(
+            [graph.xlim[0], graph.xlim[1]],
+            [0, 0],
+            color="#333",
+            line_width=2,
+        )
+
+        _draw_modern_layout_sections(fig, graph.sections, graph.ylim[1])
+        _draw_modern_layout_stems(fig, graph.stems)
+        box_renderer = _draw_modern_layout_boxes(fig, graph.boxes)
+        marker_renderers = _draw_modern_layout_markers(fig, graph.markers)
+
+        if add_named_hover:
+            if box_renderer is not None:
+                fig.add_tools(
+                    bokeh.models.HoverTool(
+                        renderers=[box_renderer],
+                        tooltips=[
+                            ("type", "@type"),
+                            ("name", "@name"),
+                            ("s", "@s_start{0.000} → @s_end{0.000} m"),
+                            ("L", "@L{0.000} m"),
+                        ],
+                    )
+                )
+            if marker_renderers:
+                fig.add_tools(
+                    bokeh.models.HoverTool(
+                        renderers=marker_renderers,
+                        tooltips=[
+                            ("type", "@type"),
+                            ("name", "@name"),
+                            ("s", "@x{0.000} m"),
+                        ],
+                    )
+                )
+
+        if self.x_range is not None:
+            fig.x_range = self.x_range
+
+        fig.y_range = bokeh.models.Range1d(
+            start=graph.ylim[0], end=graph.ylim[1], bounds=graph.ylim
+        )
+        return fig
+
+
+def _draw_modern_layout_sections(
+    fig: figure, sections: list[LayoutSection], y_top: float
+) -> None:
+    if not sections:
+        return
+    label_data = {"x": [], "y": [], "text": []}
+    for sec in sections:
+        fig.add_layout(
+            bokeh.models.Span(
+                location=sec.s_min,
+                dimension="height",
+                line_color="#bbb",
+                line_dash="dashed",
+                line_width=1,
+                level="underlay",
+            )
+        )
+        label_data["x"].append(sec.s_min)
+        label_data["y"].append(y_top * 0.92)
+        label_data["text"].append(sec.name)
+    fig.add_layout(
+        bokeh.models.LabelSet(
+            x="x",
+            y="y",
+            text="text",
+            source=ColumnDataSource(label_data),
+            x_offset=3,
+            text_font_size="10px",
+            text_color="#888",
+            text_font_style="bold",
+        )
+    )
+
+
+def _draw_modern_layout_stems(fig: figure, stems: StemData):
+    if not stems["x0"]:
+        return None
+    return fig.segment(
+        x0="x0",
+        y0="y0",
+        x1="x1",
+        y1="y1",
+        color="color",
+        line_alpha=0.5,
+        line_width=1,
+        source=ColumnDataSource(dict(stems)),
+    )
+
+
+def _draw_modern_layout_boxes(fig: figure, boxes: BoxData):
+    if not boxes["left"]:
+        return None
+    return fig.quad(
+        left="left",
+        right="right",
+        top="top",
+        bottom="bottom",
+        color="color",
+        line_color=None,
+        fill_alpha=0.55,
+        source=ColumnDataSource(dict(boxes)),
+    )
+
+
+def _draw_modern_layout_markers(
+    fig: figure,
+    markers: dict[str, MarkerData],
+    *,
+    show_labels: bool = True,
+) -> list:
+    renderers = []
+    for shape, data in markers.items():
+        if not data["x"]:
+            continue
+        r = fig.scatter(
+            x="x",
+            y="y",
+            marker=shape,
+            color="color",
+            line_color="color",
+            size="size",
+            fill_alpha=1.0,
+            source=ColumnDataSource(dict(data)),
+        )
+        renderers.append(r)
+
+        if show_labels:
+            # Trailing portion of the name, after the first underscore — matches
+            # the convention in the reference HTML viewer.
+            label_src = ColumnDataSource(
+                {
+                    "x": list(data["x"]),
+                    "y": [y + 8 for y in data["y"]],
+                    "text": ["_".join(n.split("_")[1:]) for n in data["name"]],
+                    "color": list(data["color"]),
+                }
+            )
+            fig.add_layout(
+                bokeh.models.LabelSet(
+                    x="x",
+                    y="y",
+                    text="text",
+                    source=label_src,
+                    text_font_size="8px",
+                    text_color="color",
+                    text_align="center",
+                )
+            )
+    return renderers
+
+
 class BokehBasicGraph(BokehGraphBase[BasicGraph]):
     graph_type: ClassVar[str] = "basic"
     graph: BasicGraph
@@ -1197,7 +1441,12 @@ class BokehFloorPlanGraph(BokehGraphBase[FloorPlanGraph]):
         return []
 
 
-AnyBokehGraph = Union[BokehBasicGraph, BokehLatticeLayoutGraph, BokehFloorPlanGraph]
+AnyBokehGraph = Union[
+    BokehBasicGraph,
+    BokehLatticeLayoutGraph,
+    BokehFloorPlanGraph,
+    BokehModernLatticeLayoutGraph,
+]
 
 
 UIGridLayoutList = list[Optional[bokeh.models.UIElement]]
@@ -1323,7 +1572,8 @@ class BokehAppCreator:
         if not len(graphs):
             raise ValueError("BokehAppCreator requires 1 or more graph")
 
-        if any(isinstance(graph, LatticeLayoutGraph) for graph in graphs):
+        layout_types: tuple[type, ...] = (LatticeLayoutGraph, ModernLatticeLayoutGraph)
+        if any(isinstance(graph, layout_types) for graph in graphs):
             include_layout = False
         elif not any(graph.is_s_plot for graph in graphs):
             include_layout = False
@@ -1433,7 +1683,9 @@ class BokehAppCreator:
             rows[row].append(fig)
 
         for pair in pairs + layout_pairs:
-            is_layout = isinstance(pair.bgraph, BokehLatticeLayoutGraph)
+            is_layout = isinstance(
+                pair.bgraph, (BokehLatticeLayoutGraph, BokehModernLatticeLayoutGraph)
+            )
             width, height = _Defaults.get_size_for_class(
                 type(pair.bgraph),
                 user_width=self.width,
@@ -1705,7 +1957,7 @@ class Variable:
         return [
             cls.from_tao(
                 tao=tao,
-                name=f'{var_info["name"]}[{idx}]',
+                name=f"{var_info['name']}[{idx}]",
                 parameter=parameter,
             )
             for var_info in tao.var_general()
@@ -1740,7 +1992,10 @@ class Variable:
             record_exception(ex)
 
         for pair in pairs:
-            if isinstance(pair.bgraph, (BokehBasicGraph, BokehLatticeLayoutGraph)):
+            if isinstance(
+                pair.bgraph,
+                (BokehBasicGraph, BokehLatticeLayoutGraph, BokehModernLatticeLayoutGraph),
+            ):
                 try:
                     pair.bgraph.update_plot(pair.fig)
                 except Exception as ex:
@@ -1768,6 +2023,9 @@ class BokehGraphManager(GraphManager):
     def configure(self, **kwargs):
         return set_defaults(**kwargs)
 
+    def _default_layout_style(self) -> ModernLayoutConfig | None:
+        return _Defaults.layout_style
+
     def to_bokeh_graph(self, graph: AnyGraph) -> AnyBokehGraph:
         """
         Create a Bokeh graph instance from the backend-agnostic AnyGraph version.
@@ -1786,6 +2044,8 @@ class BokehGraphManager(GraphManager):
             return BokehBasicGraph(self, graph)
         elif isinstance(graph, LatticeLayoutGraph):
             return BokehLatticeLayoutGraph(self, graph)
+        elif isinstance(graph, ModernLatticeLayoutGraph):
+            return BokehModernLatticeLayoutGraph(self, graph)
         elif isinstance(graph, FloorPlanGraph):
             return BokehFloorPlanGraph(self, graph)
         raise NotImplementedError(type(graph).__name__)

--- a/pytao/plotting/bokeh.py
+++ b/pytao/plotting/bokeh.py
@@ -38,19 +38,18 @@ from bokeh.plotting import figure
 from pydantic.dataclasses import dataclass
 from typing_extensions import NotRequired, TypedDict
 
-from pytao.plotting.modern_layout import (
+from ..core import AnyPath, TaoCommandError
+from . import floor_plan_shapes, pgplot, util
+from .curves import CurveIndexToCurve, PlotCurveLine, PlotCurveSymbols, TaoCurveSettings
+from .fields import ElementField
+from .layout_shapes import LayoutShape
+from .modern_layout import (
     BoxData,
     MarkerData,
     ModernLatticeLayoutGraph,
     ModernLayoutConfig,
     StemData,
 )
-
-from ..core import AnyPath, TaoCommandError
-from . import floor_plan_shapes, pgplot, util
-from .curves import CurveIndexToCurve, PlotCurveLine, PlotCurveSymbols, TaoCurveSettings
-from .fields import ElementField
-from .layout_shapes import LayoutShape
 from .patches import (
     PlotPatch,
     PlotPatchArc,

--- a/pytao/plotting/bokeh.py
+++ b/pytao/plotting/bokeh.py
@@ -1177,7 +1177,7 @@ def _draw_modern_layout_markers(
                 {
                     "x": list(data["x"]),
                     "y": [y + 8 for y in data["y"]],
-                    "text": ["_".join(n.split("_")[1:]) for n in data["name"]],
+                    "text": data["name"],
                     "color": list(data["color"]),
                 }
             )

--- a/pytao/plotting/modern_layout.py
+++ b/pytao/plotting/modern_layout.py
@@ -326,24 +326,16 @@ _DEFAULT_STYLES: dict[str, ElementStyle] = {
 
 # Default classification rules. Direct key matches in `styles` win first;
 # these only run if the key isn't itself a style key.
+#
+marker_like = "^(MONITOR|INSTRUMENT|MARKER)$"
 _DEFAULT_RULES: list[dict] = [
-    # MONITOR/INSTRUMENT named like "<prefix>_<TYPE>[digits]" → style=<TYPE>.
-    {
-        "key_pattern": r"^(MONITOR|INSTRUMENT)$",
-        "name_pattern": r"^[^_]+_(?P<style>[A-Za-z]+)\d*",
-    },
-    # Fallback substring matches for the diagnostic types.
-    {"key_pattern": r"^(MONITOR|INSTRUMENT)$", "name_pattern": r"BPM", "style": "BPM"},
-    {"key_pattern": r"^(MONITOR|INSTRUMENT)$", "name_pattern": r"BSCR", "style": "BSCR"},
-    {"key_pattern": r"^(MONITOR|INSTRUMENT)$", "name_pattern": r"WRSC", "style": "WRSC"},
-    {"key_pattern": r"^(MONITOR|INSTRUMENT)$", "name_pattern": r"BLEN", "style": "BLEN"},
-    {"key_pattern": r"^(MONITOR|INSTRUMENT)$", "name_pattern": r"SLM", "style": "SLM"},
-    {"key_pattern": r"^(MONITOR|INSTRUMENT)$", "name_pattern": r"BSI", "style": "BSI"},
-    {"key_pattern": r"^(MONITOR|INSTRUMENT)$", "name_pattern": r"FCUP", "style": "FCUP"},
-    # Some lattices use the ``MARKER`` key for BPMs. If "BPM" appears
-    # anywhere in the name, treat it as a BPM; other markers fall through
-    # to the default skip behavior.
-    {"key_pattern": r"^MARKER$", "name_pattern": r"BPM", "style": "BPM"},
+    {"key_pattern": marker_like, "name_pattern": "BPM", "style": "BPM"},
+    {"key_pattern": marker_like, "name_pattern": "BSCR", "style": "BSCR"},
+    {"key_pattern": marker_like, "name_pattern": "WRSC", "style": "WRSC"},
+    {"key_pattern": marker_like, "name_pattern": "BLEN", "style": "BLEN"},
+    {"key_pattern": marker_like, "name_pattern": "SLM", "style": "SLM"},
+    {"key_pattern": marker_like, "name_pattern": "BSI", "style": "BSI"},
+    {"key_pattern": marker_like, "name_pattern": "FCUP", "style": "FCUP"},
 ]
 
 

--- a/pytao/plotting/modern_layout.py
+++ b/pytao/plotting/modern_layout.py
@@ -203,16 +203,21 @@ class ModernLayoutConfig(TaoBaseModel, extra="forbid"):
         return type(self).model_validate(data)
 
     def classify(self, key: str, name: str) -> ElementStyle | None:
-        """Return the matched ``ElementStyle``, or None to skip the element."""
+        """Return the matched ``ElementStyle``, or None to skip the element.
+
+        Rules are checked before ``skip_keys`` so a rule can promote an
+        element whose Bmad key would otherwise be hidden (e.g. a ``MARKER``
+        whose name identifies it as a BPM).
+        """
         key = key.upper()
-        if key in self.skip_keys:
-            return None
         if key in self.styles:
             return self.styles[key]
         for rule in self.rules:
             style_key = rule.match(key, name)
             if style_key is not None and style_key in self.styles:
                 return self.styles[style_key]
+        if key in self.skip_keys:
+            return None
         return None
 
 
@@ -335,6 +340,10 @@ _DEFAULT_RULES: list[dict] = [
     {"key_pattern": r"^(MONITOR|INSTRUMENT)$", "name_pattern": r"SLM", "style": "SLM"},
     {"key_pattern": r"^(MONITOR|INSTRUMENT)$", "name_pattern": r"BSI", "style": "BSI"},
     {"key_pattern": r"^(MONITOR|INSTRUMENT)$", "name_pattern": r"FCUP", "style": "FCUP"},
+    # Some lattices use the ``MARKER`` key for BPMs. If "BPM" appears
+    # anywhere in the name, treat it as a BPM; other markers fall through
+    # to the default skip behavior.
+    {"key_pattern": r"^MARKER$", "name_pattern": r"BPM", "style": "BPM"},
 ]
 
 

--- a/pytao/plotting/modern_layout.py
+++ b/pytao/plotting/modern_layout.py
@@ -1,0 +1,629 @@
+from __future__ import annotations
+
+import logging
+import re
+import typing
+from functools import cached_property
+from typing import ClassVar, Literal, Pattern
+
+import pydantic
+import pydantic.dataclasses as dataclasses
+from pydantic import ConfigDict
+from pydantic.fields import Field
+from typing_extensions import TypedDict
+
+from ..model import Element, Lattice
+from ..model.base import TaoBaseModel
+from .plot import (
+    GraphBase,
+    NoLayoutError,
+    _clean_pytao_output,
+    _point_field,
+    get_plot_graph_info,
+)
+from .types import PlotGraphInfo, PlotRegionInfo, Point
+
+if typing.TYPE_CHECKING:
+    from .. import Tao
+
+logger = logging.getLogger(__name__)
+
+_dcls_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class BoxData(TypedDict):
+    """Pre-bucketed magnet rectangles, one entry per element."""
+
+    left: list[float]
+    right: list[float]
+    top: list[float]
+    bottom: list[float]
+    color: list[str]
+    name: list[str]
+    type: list[str]
+    L: list[float]
+    s_start: list[float]
+    s_end: list[float]
+
+
+class StemData(TypedDict):
+    """Vertical stem segments connecting beamline to off-axis markers."""
+
+    x0: list[float]
+    y0: list[float]
+    x1: list[float]
+    y1: list[float]
+    color: list[str]
+
+
+class MarkerData(TypedDict):
+    """One bucket per marker shape — driven into a single scatter call."""
+
+    x: list[float]
+    y: list[float]
+    color: list[str]
+    size: list[float]
+    name: list[str]
+    type: list[str]
+
+
+Position = Literal["center", "above", "below"]
+# "box" and "stem" are special-cased renderers (rectangles and vertical lines);
+# every other value is a Bokeh marker name passed straight through to
+# ``fig.scatter(marker=...)``.
+Shape = Literal[
+    "box",
+    "stem",
+    "asterisk",
+    "circle",
+    "circle_cross",
+    "circle_dot",
+    "circle_x",
+    "circle_y",
+    "cross",
+    "dash",
+    "diamond",
+    "diamond_cross",
+    "diamond_dot",
+    "dot",
+    "hex",
+    "hex_dot",
+    "inverted_triangle",
+    "plus",
+    "square",
+    "square_cross",
+    "square_dot",
+    "square_pin",
+    "square_x",
+    "star",
+    "star_dot",
+    "triangle",
+    "triangle_dot",
+    "triangle_pin",
+    "x",
+    "y",
+]
+
+
+class ElementStyle(TaoBaseModel, extra="forbid"):
+    label: str
+    color: str = "#888"
+    shape: Shape = "box"
+    height: float = 16.0
+    size: float = 8.0
+    position: Position = "center"
+    tier: float | None = None
+
+
+class ClassifyRule(TaoBaseModel, extra="forbid"):
+    """
+    Map (Element.key, Element.name) → a style key by regex.
+
+    Either ``style`` is set explicitly, or ``name_pattern`` carries a
+    ``(?P<style>...)`` group whose capture is used as the style key.
+    """
+
+    key_pattern: str
+    name_pattern: str | None = None
+    style: str | None = None
+
+    _key_re: Pattern[str] = pydantic.PrivateAttr()
+    _name_re: Pattern[str] | None = pydantic.PrivateAttr(default=None)
+
+    def model_post_init(self, _ctx) -> None:
+        self._key_re = re.compile(self.key_pattern)
+        self._name_re = re.compile(self.name_pattern) if self.name_pattern else None
+        if self.style is None and (
+            self._name_re is None or "style" not in self._name_re.groupindex
+        ):
+            raise ValueError(
+                "ClassifyRule must set `style` or supply a name_pattern with a "
+                "(?P<style>...) named group"
+            )
+
+    def match(self, key: str, name: str) -> str | None:
+        if not self._key_re.search(key):
+            return None
+        if self._name_re is None:
+            return self.style
+        m = self._name_re.search(name)
+        if m is None:
+            return None
+        if "style" in self._name_re.groupindex:
+            return m.group("style")
+        return self.style
+
+
+class LayoutSection(TaoBaseModel, extra="forbid"):
+    name: str
+    s_min: float
+    s_max: float | None = None
+
+
+class ModernLayoutConfig(TaoBaseModel, extra="forbid"):
+    """Configuration for the modern lattice layout plot.
+
+    A non-``None`` config on a :class:`GraphManager` replaces the default
+    Tao-driven ``lat_layout`` graph with a :class:`ModernLatticeLayoutGraph`.
+    """
+
+    styles: dict[str, ElementStyle] = pydantic.Field(default_factory=dict)
+    skip_keys: set[str] = pydantic.Field(default_factory=set)
+    rules: list[ClassifyRule] = pydantic.Field(default_factory=list)
+    sections: list[LayoutSection] | None = None
+    section_pattern: str | None = None
+
+    @classmethod
+    def default(cls) -> ModernLayoutConfig:
+        return cls(
+            styles=dict(_DEFAULT_STYLES),
+            skip_keys=set(_DEFAULT_SKIP_KEYS),
+            rules=[ClassifyRule(**r) for r in _DEFAULT_RULES],
+        )
+
+    def with_overrides(self, **patches) -> ModernLayoutConfig:
+        """
+        Return a deep-merged copy.
+
+        ``styles=`` accepts partial dicts: ``{"SBEND": {"color": "red"}}``
+        merges into the existing ``SBEND`` style instead of replacing it.
+        """
+        data = self.model_dump()
+        for key, value in patches.items():
+            if key == "styles" and isinstance(value, dict):
+                merged = dict(data.get("styles") or {})
+                for sk, sv in value.items():
+                    if isinstance(sv, dict) and sk in merged:
+                        merged[sk] = {**merged[sk], **sv}
+                    else:
+                        merged[sk] = sv
+                data["styles"] = merged
+            else:
+                data[key] = value
+        return type(self).model_validate(data)
+
+    def classify(self, key: str, name: str) -> ElementStyle | None:
+        """Return the matched ``ElementStyle``, or None to skip the element."""
+        key = key.upper()
+        if key in self.skip_keys:
+            return None
+        if key in self.styles:
+            return self.styles[key]
+        for rule in self.rules:
+            style_key = rule.match(key, name)
+            if style_key is not None and style_key in self.styles:
+                return self.styles[style_key]
+        return None
+
+
+# Defaults below mirror the script the user provided so out-of-the-box
+# behavior matches it.
+
+_DEFAULT_SKIP_KEYS: set[str] = {
+    "OVERLAY",
+    "PIPE",
+    "MARKER",
+    "EM_FIELD",
+    "PATCH",
+    "THICK_MULTIPOLE",
+    "GKICKER",
+    "E_GUN",
+    "BEGINNING_ELE",
+}
+
+_DEFAULT_STYLES: dict[str, ElementStyle] = {
+    # Magnets — drawn as boxes centered on the beamline.
+    "SBEND": ElementStyle(label="Dipole", color="#CC0000", shape="box", height=30),
+    "QUADRUPOLE": ElementStyle(label="Quadrupole", color="#0044CC", shape="box", height=24),
+    "SEXTUPOLE": ElementStyle(label="Sextupole", color="#CCCC00", shape="box", height=18),
+    "OCTUPOLE": ElementStyle(label="Octupole", color="#7B2D8E", shape="box", height=16),
+    "LCAVITY": ElementStyle(label="RF Cavity", color="#228B22", shape="box", height=28),
+    "SOLENOID": ElementStyle(label="Solenoid", color="#9B30FF", shape="box", height=22),
+    "WIGGLER": ElementStyle(label="Wiggler", color="#E8A317", shape="box", height=26),
+    "ECOLLIMATOR": ElementStyle(label="Collimator", color="#222222", shape="box", height=20),
+    "KICKER": ElementStyle(label="Kicker", color="#888888", shape="box", height=12),
+    "HKICKER": ElementStyle(label="H-Corrector", color="#888888", shape="box", height=12),
+    "VKICKER": ElementStyle(label="V-Corrector", color="#888888", shape="box", height=12),
+    # Diagnostics — markers on tier offsets above (or below) the beamline.
+    "BPM": ElementStyle(
+        label="BPM", color="#0066FF", shape="diamond", size=8, position="above", tier=22
+    ),
+    "BSCR": ElementStyle(
+        label="Screen", color="#FF6600", shape="triangle", size=10, position="above", tier=42
+    ),
+    "WRSC": ElementStyle(
+        label="Wire Scanner",
+        color="#009933",
+        shape="circle",
+        size=8,
+        position="above",
+        tier=62,
+    ),
+    "BLEN": ElementStyle(
+        label="Bunch Length",
+        color="#CC00CC",
+        shape="square",
+        size=8,
+        position="above",
+        tier=82,
+    ),
+    "SLM": ElementStyle(
+        label="Synch. Light",
+        color="#FFD700",
+        shape="star",
+        size=10,
+        position="above",
+        tier=102,
+    ),
+    "BSI": ElementStyle(
+        label="Beam Stop", color="#333333", shape="cross", size=10, position="above", tier=42
+    ),
+    "FCUP": ElementStyle(
+        label="Faraday Cup", color="#8B4513", shape="circle", size=8, position="above", tier=62
+    ),
+    "DG": ElementStyle(
+        label="Diag. Line",
+        color="#FF1493",
+        shape="triangle",
+        size=10,
+        position="above",
+        tier=82,
+    ),
+    "SPEC": ElementStyle(
+        label="Spectrometer",
+        color="#4169E1",
+        shape="square",
+        size=10,
+        position="above",
+        tier=102,
+    ),
+    "TCAV": ElementStyle(
+        label="Transv. Cavity",
+        color="#20B2AA",
+        shape="diamond",
+        size=10,
+        position="above",
+        tier=102,
+    ),
+    "BCM": ElementStyle(
+        label="Current Mon.",
+        color="#00CED1",
+        shape="square",
+        size=8,
+        position="above",
+        tier=22,
+    ),
+    # Stem-only marker (drawn below beamline as a vertical tick).
+    "BLM": ElementStyle(
+        label="BLM", color="#CC5599", shape="stem", size=6, position="below", tier=-15
+    ),
+}
+
+# Default classification rules. Direct key matches in `styles` win first;
+# these only run if the key isn't itself a style key.
+_DEFAULT_RULES: list[dict] = [
+    # MONITOR/INSTRUMENT named like "<prefix>_<TYPE>[digits]" → style=<TYPE>.
+    {
+        "key_pattern": r"^(MONITOR|INSTRUMENT)$",
+        "name_pattern": r"^[^_]+_(?P<style>[A-Za-z]+)\d*",
+    },
+    # Fallback substring matches for the diagnostic types.
+    {"key_pattern": r"^(MONITOR|INSTRUMENT)$", "name_pattern": r"BPM", "style": "BPM"},
+    {"key_pattern": r"^(MONITOR|INSTRUMENT)$", "name_pattern": r"BSCR", "style": "BSCR"},
+    {"key_pattern": r"^(MONITOR|INSTRUMENT)$", "name_pattern": r"WRSC", "style": "WRSC"},
+    {"key_pattern": r"^(MONITOR|INSTRUMENT)$", "name_pattern": r"BLEN", "style": "BLEN"},
+    {"key_pattern": r"^(MONITOR|INSTRUMENT)$", "name_pattern": r"SLM", "style": "SLM"},
+    {"key_pattern": r"^(MONITOR|INSTRUMENT)$", "name_pattern": r"BSI", "style": "BSI"},
+    {"key_pattern": r"^(MONITOR|INSTRUMENT)$", "name_pattern": r"FCUP", "style": "FCUP"},
+]
+
+
+@dataclasses.dataclass(config=_dcls_config)
+class ModernElement:
+    info: Element
+    style: ElementStyle
+
+
+class LayoutData(TaoBaseModel, extra="forbid"):
+    """Plotting-agnostic per-branch lattice layout data."""
+
+    branch: int = 0
+    universe: int = 1
+    branch_name: str = ""
+    s_min: float = 0.0
+    s_max: float = 0.0
+    elements: list[Element] = pydantic.Field(default_factory=list)
+    sections: list[LayoutSection] = pydantic.Field(default_factory=list)
+
+    @classmethod
+    def from_tao(
+        cls,
+        tao: Tao,
+        *,
+        ix_uni: int = 1,
+        ix_branch: int = 0,
+        sections: list[LayoutSection] | None = None,
+        section_pattern: str | None = None,
+    ) -> LayoutData:
+        lat = Lattice.from_tao_tracking(
+            tao,
+            ix_uni=str(ix_uni),
+            ix_branch=str(ix_branch),
+            defaults=False,
+        )
+
+        elements = list(lat.elements)
+
+        s_min = float(min(ele.head.s_start for ele in elements)) if elements else 0.0
+        s_max = float(max(ele.head.s for ele in elements)) if elements else 0.0
+
+        if sections is not None:
+            resolved_sections = list(sections)
+        elif section_pattern is not None:
+            resolved_sections = _sections_from_pattern(elements, section_pattern)
+        else:
+            resolved_sections = []
+
+        branch1 = tao.branch1(ix_uni=ix_uni, ix_branch=ix_branch)
+
+        return cls(
+            branch=ix_branch,
+            universe=ix_uni,
+            branch_name=branch1.get("name", f"{ix_uni}@{ix_branch}"),
+            s_min=s_min,
+            s_max=s_max,
+            elements=elements,
+            sections=resolved_sections,
+        )
+
+
+def _sections_from_pattern(
+    elements: list[Element],
+    pattern: str,
+) -> list[LayoutSection]:
+    """
+    Walk elements, emitting a section each time the regex matches a new name.
+
+    If the pattern carries a ``(?P<name>...)`` group, that capture is the
+    section name; otherwise the matched substring is used. Adjacent
+    duplicates collapse into one section.
+    """
+    rx = re.compile(pattern)
+    out: list[LayoutSection] = []
+    last: str | None = None
+    for elem in elements:
+        m = rx.search(elem.head.name)
+        if m is None:
+            continue
+        name = m.groupdict().get("name") or m.group(0)
+        if name == last:
+            continue
+        if out:
+            out[-1].s_max = elem.head.s_start
+        out.append(LayoutSection(name=name, s_min=elem.head.s_start))
+        last = name
+    if out:
+        out[-1].s_max = elements[-1].head.s if elements else out[-1].s_min
+    return out
+
+
+@dataclasses.dataclass(config=_dcls_config)
+class ModernLatticeLayoutGraph(GraphBase):
+    """Replacement for ``LatticeLayoutGraph`` driven by ``ModernLayoutConfig``.
+
+    Used in place of the default ``lat_layout`` graph when a non-``None``
+    ``layout_style`` is configured on the active :class:`GraphManager`. The
+    Bokeh and matplotlib renderers in ``pytao.plotting.bokeh`` /
+    ``pytao.plotting.mpl`` consume the pre-bucketed ``boxes`` / ``stems`` /
+    ``markers`` views.
+    """
+
+    graph_type: ClassVar[str] = "modern_lat_layout"
+
+    data: LayoutData = Field(default_factory=LayoutData)
+    elements: list[ModernElement] = Field(default_factory=list)
+    sections: list[LayoutSection] = Field(default_factory=list)
+    config: ModernLayoutConfig = Field(default_factory=ModernLayoutConfig.default)
+    branch: int = 0
+    universe: int = 1
+    border_xlim: Point = _point_field
+
+    @property
+    def is_s_plot(self) -> bool:
+        return True
+
+    @property
+    def y_min(self) -> float:
+        return self.ylim[0]
+
+    @property
+    def y_max(self) -> float:
+        return self.ylim[1]
+
+    @cached_property
+    def boxes(self) -> BoxData:
+        data: BoxData = {
+            "left": [],
+            "right": [],
+            "top": [],
+            "bottom": [],
+            "color": [],
+            "name": [],
+            "type": [],
+            "L": [],
+            "s_start": [],
+            "s_end": [],
+        }
+        for se in self.elements:
+            if se.style.shape != "box":
+                continue
+            h = se.style.height
+            head = se.info.head
+            data["left"].append(head.s_start)
+            data["right"].append(head.s)
+            data["top"].append(h / 2.0)
+            data["bottom"].append(-h / 2.0)
+            data["color"].append(se.style.color)
+            data["name"].append(head.name)
+            data["type"].append(se.style.label)
+            data["L"].append(head.s - head.s_start)
+            data["s_start"].append(head.s_start)
+            data["s_end"].append(head.s)
+        return data
+
+    @cached_property
+    def stems(self) -> StemData:
+        data: StemData = {"x0": [], "y0": [], "x1": [], "y1": [], "color": []}
+        for se in self.elements:
+            if se.style.shape == "box":
+                continue
+            head = se.info.head
+            s = (head.s_start + head.s) / 2.0
+            tier = _resolve_tier(se.style)
+            if se.style.position == "below":
+                y0, y1 = tier, 0.0
+            else:
+                y0, y1 = 0.0, tier
+            data["x0"].append(s)
+            data["x1"].append(s)
+            data["y0"].append(y0)
+            data["y1"].append(y1)
+            data["color"].append(se.style.color)
+        return data
+
+    @cached_property
+    def markers(self) -> dict[Shape, MarkerData]:
+        out: dict[Shape, MarkerData] = {}
+        for se in self.elements:
+            shape = se.style.shape
+            if shape in ("box", "stem"):
+                continue
+            head = se.info.head
+            s = (head.s_start + head.s) / 2.0
+            tier = _resolve_tier(se.style)
+            bucket = out.setdefault(
+                shape,
+                {"x": [], "y": [], "color": [], "size": [], "name": [], "type": []},
+            )
+            bucket["x"].append(s)
+            bucket["y"].append(tier)
+            bucket["color"].append(se.style.color)
+            # Script doubled viz_config "size" to get bokeh screen-px diameter
+            # parity. Renderers can scale further if they want.
+            bucket["size"].append(se.style.size * 2)
+            bucket["name"].append(head.name)
+            bucket["type"].append(se.style.label)
+        return out
+
+    @classmethod
+    def from_tao(
+        cls,
+        tao: Tao,
+        region_name: str = "lat_layout",
+        graph_name: str = "g",
+        *,
+        config: ModernLayoutConfig | None = None,
+        info: PlotGraphInfo | None = None,
+        template_name: str | None = None,
+        template_graph_index: int | None = None,
+        **_unused,
+    ) -> ModernLatticeLayoutGraph:
+        cfg = config if config is not None else ModernLayoutConfig.default()
+
+        if info is None:
+            try:
+                info = get_plot_graph_info(tao, region_name, graph_name)
+            except ValueError:
+                raise NoLayoutError(f"No layout named {region_name}.{graph_name}") from None
+
+        region_info = _clean_pytao_output(tao.plot1(region_name), PlotRegionInfo)
+
+        universe = 1 if info["ix_universe"] == -1 else info["ix_universe"]
+        ix_branch = info["-1^ix_branch"]
+        if ix_branch < 0:
+            ix_branch = 0
+
+        data = LayoutData.from_tao(
+            tao,
+            ix_uni=universe,
+            ix_branch=ix_branch,
+            sections=cfg.sections,
+            section_pattern=cfg.section_pattern,
+        )
+
+        elements: list[ModernElement] = []
+        for elem in data.elements:
+            head = elem.head
+            style = cfg.classify(head.key, head.name)
+            if style is None:
+                continue
+            elements.append(ModernElement(info=elem, style=style))
+
+        ylim = _ylim_from_styles(cfg, elements)
+
+        return cls(
+            data=data,
+            info=info,
+            region_info=region_info,
+            region_name=region_name,
+            graph_name=graph_name,
+            template_name=template_name,
+            template_graph_index=template_graph_index,
+            xlim=(info["x_min"], info["x_max"]),
+            ylim=ylim,
+            border_xlim=(1.1 * info["x_min"], 1.1 * info["x_max"]),
+            universe=universe,
+            branch=ix_branch,
+            elements=elements,
+            sections=list(data.sections),
+            config=cfg,
+        )
+
+
+def _resolve_tier(style: ElementStyle) -> float:
+    if style.tier is not None:
+        return style.tier
+    if style.position == "above":
+        return 22.0
+    if style.position == "below":
+        return -15.0
+    return 0.0
+
+
+def _ylim_from_styles(
+    cfg: ModernLayoutConfig,
+    elements: list[ModernElement],
+) -> Point:
+    """Derive a vertical range that contains every glyph plus headroom.
+
+    Bottom is a fixed pad below the axis (stems hanging down rarely need
+    much room); top is the tallest glyph extent plus headroom for labels.
+    """
+    y_hi = 1.0
+    for se in elements:
+        if se.style.shape == "box":
+            y_hi = max(y_hi, se.style.height / 2.0)
+        else:
+            tier = _resolve_tier(se.style)
+            y_hi = max(y_hi, tier + se.style.size + 8.0)
+    return (-50.0, y_hi + 10.0)

--- a/pytao/plotting/mpl.py
+++ b/pytao/plotting/mpl.py
@@ -4,6 +4,7 @@ import functools
 import logging
 import pathlib
 import time
+import typing
 from collections.abc import Sequence
 from typing import ClassVar, Literal
 
@@ -21,6 +22,13 @@ import numpy as np
 from . import floor_plan_shapes, layout_shapes, pgplot
 from .curves import PlotCurveLine, PlotCurveSymbols, PlotHistogram, TaoCurveSettings
 from .fields import ElementField
+from .modern_layout import (
+    BoxData,
+    MarkerData,
+    ModernLatticeLayoutGraph,
+    ModernLayoutConfig,
+    StemData,
+)
 from .patches import (
     PlotPatch,
     PlotPatchArc,
@@ -52,6 +60,10 @@ class _Defaults:
     line_width_scale: float = 0.5
     floor_line_width_scale: float = 0.5
     colormap: str = "PRGn_r"
+    layout_style: ModernLayoutConfig | None = None
+
+
+_UNSET = object()
 
 
 def set_defaults(
@@ -63,6 +75,7 @@ def set_defaults(
     width: float | None = None,
     height: float | None = None,
     dpi: int | None = None,
+    layout_style: ModernLayoutConfig | None | object = _UNSET,
 ):
     """
     Set default values for Matplotlib plot settings.
@@ -85,6 +98,11 @@ def set_defaults(
         Height of the figure in inches. Default is as-configured in matplotlib rcParams.
     dpi : int, optional
         Dots per inch for the figure. Default is as-configured in matplotlib rcParams.
+    layout_style : ModernLayoutConfig or None, optional
+        Modern-layout config used for ``lat_layout`` graphs. When a
+        ``ModernLayoutConfig`` is supplied, layouts render via
+        :class:`ModernLatticeLayoutGraph`. Pass ``None`` to revert to the
+        Tao-driven lattice layout.
     """
 
     if layout_height is not None:
@@ -101,6 +119,8 @@ def set_defaults(
         matplotlib.rcParams["figure.figsize"] = (width, height)
     if dpi is not None:
         matplotlib.rcParams["figure.dpi"] = dpi
+    if layout_style is not _UNSET:
+        _Defaults.layout_style = typing.cast("ModernLayoutConfig | None", layout_style)
 
     info = {key: value for key, value in vars(_Defaults).items() if not key.startswith("_")}
     info["figsize"] = matplotlib.rcParams["figure.figsize"]
@@ -400,6 +420,117 @@ def plot_floor_plan_shape(
             plot_patch(patch, ax, line_width_scale=line_width_scale)
 
 
+# Bokeh marker name → matplotlib scatter marker code. Bokeh's decorated
+# variants (circle_cross, diamond_dot, …) collapse to their base shape since
+# matplotlib has no exact equivalent.
+_STYLED_LAYOUT_MPL_MARKERS: dict[str, str] = {
+    "asterisk": "*",
+    "circle": "o",
+    "circle_cross": "o",
+    "circle_dot": "o",
+    "circle_x": "o",
+    "circle_y": "o",
+    "cross": "+",
+    "dash": "_",
+    "diamond": "D",
+    "diamond_cross": "D",
+    "diamond_dot": "D",
+    "dot": ".",
+    "hex": "h",
+    "hex_dot": "h",
+    "inverted_triangle": "v",
+    "plus": "P",
+    "square": "s",
+    "square_cross": "s",
+    "square_dot": "s",
+    "square_pin": "s",
+    "square_x": "s",
+    "star": "*",
+    "star_dot": "*",
+    "triangle": "^",
+    "triangle_dot": "^",
+    "triangle_pin": "^",
+    "x": "x",
+    "y": "1",
+}
+
+
+def plot_modern_layout(
+    graph: ModernLatticeLayoutGraph,
+    ax: matplotlib.axes.Axes,
+) -> None:
+    """Render a ``ModernLatticeLayoutGraph`` onto a matplotlib axis."""
+    s_min, s_max = graph.xlim
+    y_min, y_max = graph.ylim
+
+    ax.axhline(y=0, color="#333", linewidth=1.5)
+
+    _draw_modern_layout_sections(ax, graph.sections, y_max)
+    _draw_modern_layout_stems(ax, graph.stems)
+    _draw_modern_layout_boxes(ax, graph.boxes)
+    _draw_modern_layout_markers(ax, graph.markers)
+
+    ax.set_xlim(s_min, s_max)
+    ax.set_ylim(y_min, y_max)
+    ax.set_xlabel("s (m)")
+    ax.yaxis.set_visible(False)
+    ax.grid(visible=False)
+
+
+def _draw_modern_layout_sections(ax, sections, y_top: float) -> None:
+    for sec in sections:
+        ax.axvline(x=sec.s_min, color="#bbb", linestyle="--", linewidth=0.8)
+        ax.text(
+            sec.s_min,
+            y_top * 0.92,
+            sec.name,
+            color="#888",
+            fontsize=8,
+            fontweight="bold",
+        )
+
+
+def _draw_modern_layout_stems(ax, stems: StemData) -> None:
+    for x0, y0, x1, y1, color in zip(
+        stems["x0"], stems["y0"], stems["x1"], stems["y1"], stems["color"]
+    ):
+        ax.plot([x0, x1], [y0, y1], color=color, alpha=0.5, linewidth=1)
+
+
+def _draw_modern_layout_boxes(ax, boxes: BoxData) -> None:
+    for left, right, top, bottom, color in zip(
+        boxes["left"], boxes["right"], boxes["top"], boxes["bottom"], boxes["color"]
+    ):
+        ax.add_patch(
+            matplotlib.patches.Rectangle(
+                (left, bottom),
+                width=max(right - left, 0.0),
+                height=top - bottom,
+                facecolor=color,
+                edgecolor="none",
+                alpha=0.55,
+            )
+        )
+
+
+def _draw_modern_layout_markers(ax, markers: dict[str, MarkerData]) -> None:
+    for shape, data in markers.items():
+        marker = _STYLED_LAYOUT_MPL_MARKERS.get(shape)
+        if marker is None or not data["x"]:
+            continue
+        # Matplotlib scatter `s` is area in pt^2; bokeh size is diameter in
+        # screen px. Square the per-point diameter to roughly match weight.
+        sizes = [s * s for s in data["size"]]
+        ax.scatter(
+            data["x"],
+            data["y"],
+            c=data["color"],
+            s=sizes,
+            marker=marker,
+            linewidths=0,
+        )
+
+
 def plot(graph: AnyGraph, ax: matplotlib.axes.Axes | None = None) -> matplotlib.axes.Axes:
     if ax is None:
         _, ax = plt.subplots()
@@ -442,6 +573,8 @@ def plot(graph: AnyGraph, ax: matplotlib.axes.Axes | None = None) -> matplotlib.
         # ax.set_xticks([elem.info["ele_s_start"] for elem in self.elements])
         # ax.set_xticklabels([elem.info["label_name"] for elem in self.elements], rotation=90)
         ax.grid(visible=False)
+    elif isinstance(graph, ModernLatticeLayoutGraph):
+        plot_modern_layout(graph, ax)
     elif isinstance(graph, FloorPlanGraph):
         ax.set_aspect("equal")
         for elem in graph.elements:
@@ -475,6 +608,9 @@ class MatplotlibGraphManager(GraphManager):
     @functools.wraps(set_defaults)
     def configure(self, **kwargs):
         return set_defaults(**kwargs)
+
+    def _default_layout_style(self) -> ModernLayoutConfig | None:
+        return _Defaults.layout_style
 
     def plot_grid(
         self,
@@ -707,9 +843,10 @@ class MatplotlibGraphManager(GraphManager):
 
         figsize = get_figsize(figsize, width, height)
 
+        layout_types: tuple[type, ...] = (LatticeLayoutGraph, ModernLatticeLayoutGraph)
         if (
             include_layout
-            and not any(isinstance(graph, LatticeLayoutGraph) for graph in graphs)
+            and not any(isinstance(graph, layout_types) for graph in graphs)
             and any(graph.is_s_plot for graph in graphs)
         ):
             layout_graph = self.lattice_layout_graph
@@ -754,7 +891,7 @@ class MatplotlibGraphManager(GraphManager):
             except UnsupportedGraphError:
                 continue
 
-            if isinstance(graph, LatticeLayoutGraph) and len(graphs) > 1:
+            if isinstance(graph, layout_types) and len(graphs) > 1:
                 # Do not set ylimits if the user specifically requested a layout graph
                 yl = None
             else:

--- a/pytao/plotting/mpl.py
+++ b/pytao/plotting/mpl.py
@@ -487,6 +487,8 @@ def _draw_modern_layout_sections(ax, sections, y_top: float) -> None:
             color="#888",
             fontsize=8,
             fontweight="bold",
+            clip_on=True,
+            in_layout=False,
         )
 
 
@@ -547,6 +549,8 @@ def _draw_modern_layout_markers(
                     fontsize=6,
                     ha="center",
                     va="bottom",
+                    clip_on=True,
+                    in_layout=False,
                 )
 
 

--- a/pytao/plotting/mpl.py
+++ b/pytao/plotting/mpl.py
@@ -423,7 +423,7 @@ def plot_floor_plan_shape(
 # Bokeh marker name → matplotlib scatter marker code. Bokeh's decorated
 # variants (circle_cross, diamond_dot, …) collapse to their base shape since
 # matplotlib has no exact equivalent.
-_STYLED_LAYOUT_MPL_MARKERS: dict[str, str] = {
+_MODERN_LAYOUT_MPL_MARKERS: dict[str, str] = {
     "asterisk": "*",
     "circle": "o",
     "circle_cross": "o",
@@ -513,14 +513,19 @@ def _draw_modern_layout_boxes(ax, boxes: BoxData) -> None:
         )
 
 
-def _draw_modern_layout_markers(ax, markers: dict[str, MarkerData]) -> None:
+def _draw_modern_layout_markers(
+    ax,
+    markers: dict[str, MarkerData],
+    *,
+    show_labels: bool = True,
+) -> None:
     for shape, data in markers.items():
-        marker = _STYLED_LAYOUT_MPL_MARKERS.get(shape)
+        marker = _MODERN_LAYOUT_MPL_MARKERS.get(shape)
         if marker is None or not data["x"]:
             continue
-        # Matplotlib scatter `s` is area in pt^2; bokeh size is diameter in
-        # screen px. Square the per-point diameter to roughly match weight.
-        sizes = [s * s for s in data["size"]]
+        # screen-px diameter source data (bokeh). Matplotlib area in square pts
+        # try to match area here
+        sizes = [(s / 2) ** 2 for s in data["size"]]
         ax.scatter(
             data["x"],
             data["y"],
@@ -529,6 +534,20 @@ def _draw_modern_layout_markers(ax, markers: dict[str, MarkerData]) -> None:
             marker=marker,
             linewidths=0,
         )
+
+        if show_labels:
+            for x, y, name, color in zip(data["x"], data["y"], data["name"], data["color"]):
+                if not name:
+                    continue
+                ax.text(
+                    x,
+                    y + 4,
+                    name,
+                    color=color,
+                    fontsize=6,
+                    ha="center",
+                    va="bottom",
+                )
 
 
 def plot(graph: AnyGraph, ax: matplotlib.axes.Axes | None = None) -> matplotlib.axes.Axes:

--- a/pytao/plotting/plot.py
+++ b/pytao/plotting/plot.py
@@ -1286,7 +1286,7 @@ class GraphManager(ABC):
             if not kept:
                 del self.regions[region_name]
             elif len(kept) != len(graphs):
-                self.regions[region_name] = kept
+                self.regions[region_name] = list(kept)
 
     def tao_init_hook(self) -> None:
         """Tao has reinitialized; clear our state."""

--- a/pytao/plotting/plot.py
+++ b/pytao/plotting/plot.py
@@ -1257,17 +1257,36 @@ class GraphManager(ABC):
 
     @layout_style.setter
     def layout_style(self, value: ModernLayoutConfig | None) -> None:
+        prev = self.layout_style
         self._layout_style_override = value
         self._layout_style_set = True
+        if value is not prev:
+            self._evict_layout_graphs()
 
     @layout_style.deleter
     def layout_style(self) -> None:
+        prev = self.layout_style
         self._layout_style_override = None
         self._layout_style_set = False
+        if self.layout_style is not prev:
+            self._evict_layout_graphs()
 
     def _default_layout_style(self) -> ModernLayoutConfig | None:
         """Backend-supplied default. Base manager has none."""
         return None
+
+    def _evict_layout_graphs(self) -> None:
+        """Drop any cached lattice-layout graphs so they get replaced."""
+        from .modern_layout import ModernLatticeLayoutGraph
+
+        layout_types: tuple[type, ...] = (LatticeLayoutGraph, ModernLatticeLayoutGraph)
+        for region_name in list(self.regions):
+            graphs = self.regions[region_name]
+            kept = [g for g in graphs if not isinstance(g, layout_types)]
+            if not kept:
+                del self.regions[region_name]
+            elif len(kept) != len(graphs):
+                self.regions[region_name] = kept
 
     def tao_init_hook(self) -> None:
         """Tao has reinitialized; clear our state."""

--- a/pytao/plotting/plot.py
+++ b/pytao/plotting/plot.py
@@ -55,6 +55,7 @@ from .util import fix_grid_limits
 
 if typing.TYPE_CHECKING:
     from .. import Tao
+    from .modern_layout import ModernLayoutConfig
 
 logger = logging.getLogger(__name__)
 
@@ -1164,16 +1165,24 @@ def make_graph(
     graph_name: str,
     template_name: str | None = None,
     template_graph_index: int | None = None,
+    layout_style: ModernLayoutConfig | None = None,
 ) -> AnyGraph:
     graph_info = get_plot_graph_info(tao, region_name, graph_name)
     graph_type = graph_info["graph^type"]
 
     logger.debug(f"Creating graph {region_name}.{graph_name} ({graph_type})")
 
+    extra: dict = {}
     if graph_type == "floor_plan":
         cls = FloorPlanGraph
     elif graph_type == "lat_layout":
-        cls = LatticeLayoutGraph
+        if layout_style is not None:
+            from .modern_layout import ModernLatticeLayoutGraph
+
+            cls = ModernLatticeLayoutGraph
+            extra["config"] = layout_style
+        else:
+            cls = LatticeLayoutGraph
     elif graph_type == "key_table":
         raise UnsupportedGraphError(graph_type)
     else:
@@ -1186,6 +1195,7 @@ def make_graph(
         info=graph_info,
         template_name=template_name,
         template_graph_index=template_graph_index,
+        **extra,
     )
 
 
@@ -1202,7 +1212,15 @@ def find_unused_plot_region(tao: Tao, skip: set[str]) -> str:
     raise AllPlotRegionsInUseError("No more available plot regions.")
 
 
-AnyGraph = Union[BasicGraph, LatticeLayoutGraph, FloorPlanGraph]
+if typing.TYPE_CHECKING:
+    from .modern_layout import ModernLatticeLayoutGraph
+
+AnyGraph = Union[
+    BasicGraph,
+    LatticeLayoutGraph,
+    FloorPlanGraph,
+    "ModernLatticeLayoutGraph",
+]
 
 
 class GraphManager(ABC):
@@ -1222,6 +1240,34 @@ class GraphManager(ABC):
         self.tao = tao
         self.regions = {}
         self._to_place = {}
+        self._layout_style_override: ModernLayoutConfig | None = None
+        self._layout_style_set: bool = False
+
+    @property
+    def layout_style(self) -> ModernLayoutConfig | None:
+        """Modern-layout config used for ``lat_layout`` graphs.
+
+        Reads through to the backend module's ``_Defaults.layout_style``
+        unless explicitly set on this manager instance (including being set
+        to ``None``).
+        """
+        if self._layout_style_set:
+            return self._layout_style_override
+        return self._default_layout_style()
+
+    @layout_style.setter
+    def layout_style(self, value: ModernLayoutConfig | None) -> None:
+        self._layout_style_override = value
+        self._layout_style_set = True
+
+    @layout_style.deleter
+    def layout_style(self) -> None:
+        self._layout_style_override = None
+        self._layout_style_set = False
+
+    def _default_layout_style(self) -> ModernLayoutConfig | None:
+        """Backend-supplied default. Base manager has none."""
+        return None
 
     def tao_init_hook(self) -> None:
         """Tao has reinitialized; clear our state."""
@@ -1249,13 +1295,16 @@ class GraphManager(ABC):
     @property
     def lattice_layout_graph(self) -> LatticeLayoutGraph:
         """The lattice layout graph.  Placed if not already available."""
+        from .modern_layout import ModernLatticeLayoutGraph
+
+        layout_types: tuple[type, ...] = (LatticeLayoutGraph, ModernLatticeLayoutGraph)
         for region in self.regions.values():
             for graph in region:
-                if isinstance(graph, LatticeLayoutGraph):
+                if isinstance(graph, layout_types):
                     return graph
 
         (graph,) = self.place(self.layout_template)
-        assert isinstance(graph, LatticeLayoutGraph)
+        assert isinstance(graph, layout_types)
         return graph
 
     @property
@@ -1731,6 +1780,7 @@ class GraphManager(ABC):
             graph_name=graph_name,
             template_name=template_name,
             template_graph_index=template_graph_index,
+            layout_style=self.layout_style,
         )
 
     @abstractmethod


### PR DESCRIPTION
## Changes

Adds a new "modern" layout, with bokeh/matplotlib backend support.

This layout allows for you to more easily see elements of your choice with specific markers that stand out when compared to the other elements. For example, you might configure this to have all diagnostics appear more prominently.

This is a work-in-progress and the API is likely not what the final version will look like.
There are some facility-specific bits that might need to be generalized before this gets merged.

Feedback/criticisms are welcome, as always.

## Screenshots

See the new notebook to play around with the feature.

### Bokeh

<img width="992" height="633" alt="image" src="https://github.com/user-attachments/assets/187c0543-bb4e-4104-a398-6e0e7f763097" />

### Matplotlib

<img width="902" height="398" alt="image" src="https://github.com/user-attachments/assets/94fb2af8-43f0-4c11-9432-dbdbd8b99402" />

