### PR TITLE
BLD/FIX: support setuptools-scm new version

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,6 @@
 include LICENSE
+
+# git-archive export-subst are for `git archive`, not PyPI source
+# distributions:
+exclude .git_archival.txt
+exclude .gitattributes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,3 +86,4 @@ testpaths = ["pytao/tests"]
 [tool.setuptools_scm]
 version_file = "pytao/_version.py"
 fallback_version = "0.0.0.dev0"
+tag.strict = true


### PR DESCRIPTION
setuptools-scm looks in `.git_archival.txt` for information about version information when it gets a git archive.
PyPI tarballs have their own version information included.

Recent versions of ~setuptools-scm~ vcs-versioning seem to prioritize `.git_archival.txt` over the pkg-info from the built source distribution.
Since we still include these files in the PyPI distribution, it can cause setuptools-scm to fail (depending on which version got selected).

In Bmad testing, this resulted in:
1. Success: https://github.com/bmad-sim/bmad-ecosystem/actions/runs/27993845368/job/82992006803
2. Faliure: https://github.com/bmad-sim/bmad-ecosystem/actions/runs/27992704847/job/82848280501


## Background

`vcs-versioning`, a `setuptools-scm` dependency has a fix for this specific issue: https://github.com/pypa/setuptools-scm/releases/tag/vcs-versioning-v2.1.0

> Fix fallback discovery so an unprocessed .git_archival.txt no longer shadows a valid PKG-INFO in PyPI sdists. (https://github.com/pypa/setuptools-scm/issues/1431)

We pin setuptools-scm but not vcs-versioning.

Because `sdist` includes `.git_archival.txt` (the any-platform wheel does not), this is an issue when we get the buggy version of vcs-versioning.