### PR TITLE
ENH: pytao --version (or -V)

### DIFF
--- a/pytao/cli.py
+++ b/pytao/cli.py
@@ -17,8 +17,40 @@ from .startup import TaoArgumentParser, TaoStartup, create_tao_cli_parser
 logger = logging.getLogger("pytao")
 
 
+class VersionAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        from . import __version__ as version
+        from . import SubprocessTao
+
+        print(f"PyTao {version}")
+
+        try:
+            with SubprocessTao.from_lattice_contents(
+                """
+                beginning[e_tot] = 10e6
+                parameter[geometry] = open
+                parameter[particle] = electron
+
+                d: drift, L = 0.5
+
+                lat: line = (d)
+                use, lat
+                """,
+                noplot=True,
+            ) as tao:
+                tao_version = f"{tao.version()} (from {tao.so_lib_file})"
+        except Exception as ex:
+            print(f"(Unable to determine Tao version: {ex}")
+        else:
+            print(f"Tao   {tao_version}")
+
+        sys.exit(0)
+
+
 @dataclasses.dataclass(config=ConfigDict(extra="forbid", validate_assignment=True))
 class PytaoArgs(TaoStartup):
+    version: bool = False
+
     pycommand: str | None = None
     pylog: str | None = os.environ.get("PYTAO_LOG", "WARNING") or None
     pylog_file: str | None = os.environ.get("PYTAO_LOG_FILE") or None
@@ -51,6 +83,10 @@ def create_pytao_argparser() -> argparse.ArgumentParser:
     )
 
     create_tao_cli_parser(parser)
+
+    parser.add_argument(
+        "-V", "--version", action=VersionAction, nargs=0, help="Show version and exit"
+    )
 
     parser.add_argument(
         "--pyplot",

--- a/pytao/tests/test_cli.py
+++ b/pytao/tests/test_cli.py
@@ -162,6 +162,27 @@ def test_init_logging(mock_tao_startup, restore_logging_state):
     assert "self" in call_info, "TaoStartup.run was never called!"
 
 
+def test_version_flag(capsys):
+    """The --version flag prints PyTao/Tao versions and exits."""
+    import argparse
+
+    import pytao
+
+    mock_tao = MagicMock()
+    mock_tao.version.return_value = "2024.0"
+    mock_tao.so_lib_file = "/path/to/libtao.so"
+    mock_tao.__enter__.return_value = mock_tao
+    mock_tao.__exit__.return_value = False
+
+    with patch.object(pytao.SubprocessTao, "from_lattice_contents", return_value=mock_tao):
+        with pytest.raises((SystemExit, argparse.ArgumentError)):
+            PytaoArgs.from_cli_args(["--version"])
+
+    out = capsys.readouterr().out
+    assert f"PyTao {pytao.__version__}" in out
+    assert "Tao   2024.0 (from /path/to/libtao.so)" in out
+
+
 def test_split_args_pylog_file():
     args = PytaoArgs.from_cli_args(["--pylog-file", "out.log", "-init", "init.foo"])
     assert args.pylog_file == "out.log"


### PR DESCRIPTION
Sample output:

```
$ pytao -V
PyTao 1.1.2.dev23+g3b487efc0.d20260720
Tao   20260713-0 (from /Users/klauer/Repos/bmad/debug/lib/libtao.dylib)
```

Getting the Tao version takes a little bit as it requires instantiating a small Tao instance, of course, in order to `show version`.

Closes #184 