### PR TITLE
FIX: pytao should not specify Tao's default

### DIFF
--- a/pytao/startup.py
+++ b/pytao/startup.py
@@ -372,7 +372,7 @@ class TaoStartup:
     disable_smooth_line_calc: bool = False
     external_plotting: bool = False
     geometry: str | tuple[int, int] = ""
-    hook_init_file: AnyPath | None = "tao_hook.init"
+    hook_init_file: AnyPath | None = None
     init_file: AnyPath | None = None
     lattice_file: AnyPath | None = None
     log_startup: bool = False
@@ -435,6 +435,7 @@ class TaoStartup:
             for name in self._path_fields
             if getattr(self, name) is not None
         }
+
         return replace(self, **updates)
 
     @property

--- a/pytao/tests/constraints/data/reference_results.json
+++ b/pytao/tests/constraints/data/reference_results.json
@@ -15,7 +15,7 @@
         "disable_smooth_line_calc": false,
         "external_plotting": false,
         "geometry": "",
-        "hook_init_file": "tao_hook.init",
+        "hook_init_file": null,
         "init_file": null,
         "lattice_file": "lattices/lat_a.lat.bmad",
         "log_startup": false,
@@ -54,7 +54,7 @@
         "disable_smooth_line_calc": false,
         "external_plotting": false,
         "geometry": "",
-        "hook_init_file": "tao_hook.init",
+        "hook_init_file": null,
         "init_file": null,
         "lattice_file": "lattices/lat_b.lat.bmad",
         "log_startup": false,
@@ -93,7 +93,7 @@
         "disable_smooth_line_calc": false,
         "external_plotting": false,
         "geometry": "",
-        "hook_init_file": "tao_hook.init",
+        "hook_init_file": null,
         "init_file": null,
         "lattice_file": "lattices/lat_c.lat.bmad",
         "log_startup": false,
@@ -328,7 +328,7 @@
           },
           {
             "obs_type": "datum_literal",
-            "model_value": 1.04448e-08,
+            "model_value": 1.04448e-8,
             "design_value": 0.0
           }
         ],


### PR DESCRIPTION
`hook_init_file` has a default in Tao if left unspecified.
`TaoStartup` does not need to reflect this as its default, because omitting it implies the default.

The reason behind this change is primarily that Tao's init string length has an arbitrary maximum and will truncate, leading to confusing initialization errors.

This is only seen with the constraint tool as it prepends a path to all files, lengthening the init string accordingly.