### PR TITLE
MAINT: reformat tao init files for libgfortran 16.x

### DIFF
--- a/pytao/tests/input_files/optics_matching_tweaked/tao.init
+++ b/pytao/tests/input_files/optics_matching_tweaked/tao.init
@@ -1,102 +1,99 @@
 !------------------------------------------------------------------------
 
 &tao_start
-  plot_file = 'tao_plot.init' 
+  plot_file    = 'tao_plot.init'
   startup_file = '$ACC_ROOT_DIR/bmad-doc/tao_examples/optics_matching/tao.startup'
 /
+
 !Beam Initialization
 !--------------------------------------------------------
 &tao_design_lattice
-  n_universes =1
- ! unique_name_suffix="*::_?"
+  n_universes            = 1
+  ! unique_name_suffix="*::_?"
   design_lattice(1)%file = "$ACC_ROOT_DIR/bmad-doc/tao_examples/optics_matching/lat.bmad"
 /
 
 !------------------------------------------------------------------------
 &tao_params
   !global%plot_on = True
-  global%track_type = 'single'
-  global%beam_timer_on = T
-  global%random_engine = 'pseudo'
+  global%track_type       = 'single'
+  global%beam_timer_on    = T
+  global%random_engine    = 'pseudo'
   global%de_lm_step_ratio = 1500
-  global%optimizer = 'lmdif'
-  global%n_opti_cycles = 100
+  global%optimizer        = 'lmdif'
+  global%n_opti_cycles    = 100
 
-  global%prompt_color = 'BLUE'
+  global%prompt_color                = 'BLUE'
   !---Bmad---
-  bmad_com%radiation_damping_on = F
+  bmad_com%radiation_damping_on      = F
   bmad_com%radiation_fluctuations_on = F
-  /
-
-
-&tao_beam_init
-ix_universe = 1
-saved_at =  "MARKER::*"
-beam_init%n_particle = 0
-beam_init%random_engine = 'quasi' ! or 'pseudo'
-beam_init%bunch_charge = 100.0e-12  
-beam_init%a_norm_emit = 1.0e-6  ! normalized emit = emit * gamma
-beam_init%b_norm_emit = 1.0e-6  ! normalized emit = emit * gamma
-beam_init%n_bunch = 1     
-beam_init%sig_pz = 1e-3
-beam_init%sig_z = 0.00059958  ! 2 ps * cLight
-!---Ellipse
-beam_init%distribution_type = 'ellipse', 'ran_gauss', 'grid'
-beam_init%ellipse(1)%part_per_ellipse = 50
-beam_init%ellipse(1)%n_ellipse = 3
-beam_init%ellipse(1)%sigma_cutoff = 6
-
-beam_init%grid(3)%n_x = 1
-beam_init%grid(3)%n_px = 3
-beam_init%grid(3)%x_min = 0 
-beam_init%grid(3)%x_max = 0
-beam_init%grid(3)%px_min = -0.01 
-beam_init%grid(3)%px_max =  0.01
 /
 
+&tao_beam_init
+  ix_universe                           = 1
+  saved_at                              = "MARKER::*"
+  beam_init%n_particle                  = 0
+  beam_init%random_engine               = 'quasi'                         ! or 'pseudo'
+  beam_init%bunch_charge                = 100.0e-12
+  beam_init%a_norm_emit                 = 1.0e-6                          ! normalized emit = emit * gamma
+  beam_init%b_norm_emit                 = 1.0e-6                          ! normalized emit = emit * gamma
+  beam_init%n_bunch                     = 1
+  beam_init%sig_pz                      = 1e-3
+  beam_init%sig_z                       = 0.00059958                      ! 2 ps * cLight
+  !---Ellipse
+  beam_init%distribution_type           = 'ellipse', 'ran_gauss', 'grid'
+  beam_init%ellipse(1)%part_per_ellipse = 50
+  beam_init%ellipse(1)%n_ellipse        = 3
+  beam_init%ellipse(1)%sigma_cutoff     = 6
 
-
+  beam_init%grid(3)%n_x    = 1
+  beam_init%grid(3)%n_px   = 3
+  beam_init%grid(3)%x_min  = 0
+  beam_init%grid(3)%x_max  = 0
+  beam_init%grid(3)%px_min = -0.01
+  beam_init%grid(3)%px_max = 0.01
+/
 
 !------------------------Data--------------------------------------------
 !------------------------------------------------------------------------
 
 &tao_d2_data
   d2_data%name = 'twiss'
-  n_d1_data = 2
+  n_d1_data    = 2
 /
 
 &tao_d1_data
-  ix_d1_data = 1
+  ix_d1_data   = 1
   d1_data%name = 'end'
-  datum( 1) =  'beta.a'     '' '' 'END'   'target'  12.5   1e1
-  datum( 2) =  'alpha.a'    '' '' 'END'   'target' -1.0    1e2
-  datum( 3) =  'beta.b'     '' '' 'END'   'target'  12.5   1e1
-  datum( 4) =  'alpha.b'    '' '' 'END'   'target' -1.0    1e2
-  datum( 5) =  'eta.x'      '' '' 'END'   'target'  0.0    1e1
-  datum( 6) =  'etap.x'     '' '' 'END'   'target'  0.0    1e2
+  datum(1)     = 'beta.a'     '' '' 'END'   'target'  12.5   1e1
+  datum(2)     = 'alpha.a'    '' '' 'END'   'target' -1.0    1e2
+  datum(3)     = 'beta.b'     '' '' 'END'   'target'  12.5   1e1
+  datum(4)     = 'alpha.b'    '' '' 'END'   'target' -1.0    1e2
+  datum(5)     = 'eta.x'      '' '' 'END'   'target'  0.0    1e1
+  datum(6)     = 'etap.x'     '' '' 'END'   'target'  0.0    1e2
 /
 
 &tao_d1_data
-  ix_d1_data = 2
+  ix_d1_data   = 2
   d1_data%name = 'max'
-  datum( 1) =  'beta.a'    '' 'Q1' 'END'   'max'      100   1e1
-  datum( 2) =  'eta.x'     '' 'Q1' 'END'   'abs_max'  1     1e2
-/ 
+  datum(1)     = 'beta.a'    '' 'Q1' 'END'   'max'      100   1e1
+  datum(2)     = 'eta.x'     '' 'Q1' 'END'   'abs_max'  1     1e2
+/
 
 !------------------------Variables---------------------------------------
 !------------------------------------------------------------------------
 
 &tao_var
-  v1_var%name = 'quad'
-  default_step = 1e-4
-  default_universe = '1'
-  default_attribute = 'k1'
+  v1_var%name         = 'quad'
+  default_step        = 1e-4
+  default_universe    = '1'
+  default_attribute   = 'k1'
   !default_low_lim = -50
   !default_high_lim = 50
-  default_key_delta = 1e-2
-  ix_min_var = 1
+  default_key_delta   = 1e-2
+  ix_min_var          = 1
   search_for_lat_eles = 'Quad::*'
   ! or:
   !var(1:)%ele_name = 'Q1', 'Q2', 'Q3', 'Q4', 'Q5', 'Q6'
-  default_key_bound = T
+  default_key_bound   = T
 /

--- a/pytao/tests/input_files/optics_matching_tweaked/tao_plot.init
+++ b/pytao/tests/input_files/optics_matching_tweaked/tao_plot.init
@@ -4,32 +4,31 @@ The following namelist block defines how the plot window (also called
 the plot page) is broken up.
 
 &tao_plot_page
-  plot_page%size = 800, 600
-  plot_page%text_height = 12.0 
-  plot_page%border = 0, 0, 0, 0, '%PAGE'
+  plot_page%size        = 800, 600
+  plot_page%text_height = 12.0
+  plot_page%border      = 0, 0, 0, 0, '%PAGE'
   plot_page%n_curve_pts = 900
 /
 
-
 !------------------ layout ------
 &tao_template_plot
-  plot%name = 'layout'
+  plot%name             = 'layout'
   default_graph%x%label = ' '
-  plot%n_graph = 1
-  plot%x_axis_type = 's'
+  plot%n_graph          = 1
+  plot%x_axis_type      = 's'
 /
 
 &tao_template_graph
-  graph_index = 1
-  graph%name = 'u1'
-  graph%type = 'lat_layout'
-  graph%box = 1, 1, 1, 1
-  graph%x%draw_numbers = False
-  graph%ix_universe = -1 !Syntax Changed from 0
-  graph%margin =  0.15, 0.05, 0.12, 0.12, '%BOX'
-  graph%y%max =  20
-  graph%y%min = -20
-  graph%y%major_div = 4
+  graph_index          = 1
+  graph%name           = 'u1'
+  graph%type           = 'lat_layout'
+  graph%box            = 1, 1, 1, 1
+  graph%x%draw_numbers = F
+  graph%ix_universe    = -1                              !Syntax Changed from 0
+  graph%margin         = 0.15, 0.05, 0.12, 0.12, '%BOX'
+  graph%y%max          = 20
+  graph%y%min          = -20
+  graph%y%major_div    = 4
 /
 
 &lat_layout_drawing
@@ -49,7 +48,7 @@ the plot page) is broken up.
   ele_shape(14) = "rfcavity::*"        "XBox"          "Red"    100     'none'
   ele_shape(15) = "E_GUN::*"           "XBox"          "Black"   20     'none'
   ele_shape(16) = "EM_FIELD::*"        "Box"           "Blue"    20     'none'
-/       
+/
 
 &floor_plan_drawing
   ele_shape(1)  = "Quadrupole::*"      "Box"      "Blue"    15    'none'
@@ -68,8 +67,8 @@ the plot page) is broken up.
   ele_shape(14) = "rfcavity::*"        "XBox"     "Red"     10    'none'
   ele_shape(15) = "E_GUN::*"           "XBox"     "Black"   20    'none'
   ele_shape(16) = "EM_FIELD::*"        "Box"      "Blue"    20    'none'
-/  
-                                            
+/
+
 ! Colors: 
 !"BLACK" 
 !"RED" 
@@ -113,94 +112,93 @@ the plot page) is broken up.
 ! * alpha
 
 &tao_template_plot
-  plot%name = 'alpha1'
-  plot%x%min =  0
-  plot%x%max = 10
+  plot%name        = 'alpha1'
+  plot%x%min       = 0
+  plot%x%max       = 10
   !plot%x%major_div =10
   !plot%x%label = 's (m)'
   plot%x_axis_type = 's'
   !plot%x%label_offset = 1.2
-  plot%n_graph = 1
+  plot%n_graph     = 1
 /
 
 &tao_template_graph
-  graph%name = 'a'
-  graph%x%draw_numbers = .false.
-  graph%x%draw_label = .false.
-  graph_index = 1
-  graph%box = 1, 1, 1, 1
- ! graph%title = 'Lattice \gb functions'
- ! graph%margin =  0.15, 0.06, 0.12, 0.12, '%BOX'
-  graph%margin =  0.15, 0.06, 0.06, 0.0, '%BOX'
-  graph%y%label = '\ga\dx\u, \ga\dy\u (m)'
-  graph%y%label_offset=.1
-  graph%y%max =  20
-  graph%y%min = -20
-  graph%y%major_div = 4
+  graph%name                   = 'a'
+  graph%x%draw_numbers         = F
+  graph%x%draw_label           = F
+  graph_index                  = 1
+  graph%box                    = 1, 1, 1, 1
+  ! graph%title = 'Lattice \gb functions'
+  ! graph%margin =  0.15, 0.06, 0.12, 0.12, '%BOX'
+  graph%margin                 = 0.15, 0.06, 0.06, 0.0, '%BOX'
+  graph%y%label                = '\ga\dx\u, \ga\dy\u (m)'
+  graph%y%label_offset         = .1
+  graph%y%max                  = 20
+  graph%y%min                  = -20
+  graph%y%major_div            = 4
   !!not needed: graph%n_curve = 2
-  curve(1)%smooth_line_calc = T
-  curve(1)%data_source = 'lattice'
-  curve(1)%data_type   = 'alpha.a'
+  curve(1)%smooth_line_calc    = T
+  curve(1)%data_source         = 'lattice'
+  curve(1)%data_type           = 'alpha.a'
   curve(1)%y_axis_scale_factor = 1
-  curve(1)%line%color=2
-  curve(1)%line%width=2
-  curve(1)%draw_symbols=.false.
-  curve(1)%legend_text = '\ga\dx\u'
-  curve(2)%smooth_line_calc = T
-  curve(2)%data_source = 'lattice'
-  curve(2)%data_type   = 'alpha.b'
+  curve(1)%line%color          = 'red'
+  curve(1)%line%width          = 2
+  curve(1)%draw_symbols        = F
+  curve(1)%legend_text         = '\ga\dx\u'
+  curve(2)%smooth_line_calc    = T
+  curve(2)%data_source         = 'lattice'
+  curve(2)%data_type           = 'alpha.b'
   curve(2)%y_axis_scale_factor = 1
-  curve(2)%draw_symbols= F
-  curve(2)%line%color = 3
-  curve(2)%line%width=2
-  curve(2)%legend_text = '\ga\dy\u'
+  curve(2)%draw_symbols        = F
+  curve(2)%line%color          = 'green'
+  curve(2)%line%width          = 2
+  curve(2)%legend_text         = '\ga\dy\u'
 /
-
 
 ! betadispersion
 &tao_template_plot
-  plot%name = 'betadispersion'
-  plot%x%min =  0
-  plot%x%max = 10
+  plot%name        = 'betadispersion'
+  plot%x%min       = 0
+  plot%x%max       = 10
   !plot%x%major_div =10
   !plot%x%label = 's (m)'
   plot%x_axis_type = 's'
-  plot%n_graph = 1
+  plot%n_graph     = 1
 /
 
 &tao_template_graph
-  graph%name = 'a'
-  graph%x%draw_numbers = .false.
-  graph%x%draw_label = .false.
-  graph_index = 1
-  graph%box = 1, 1, 1, 1
-  graph%title = 'Lattice \gb functions'
- ! graph%margin =  0.15, 0.06, 0.12, 0.12, '%BOX'
-  
-  graph%margin =  0.15, 0.06, 0.06, 0.12, '%BOX'
-    !----y1
-  graph%y%label = '\gb\dx\u (m), \gb\dy\u (m)'
-  graph%y%max =  20
-  graph%y%min = -20
-  graph%y%major_div = 4
-   !-----y2
-  graph%y2%label='yafaf'
-  graph%y2%max =  20
-  graph%y2%min = -20
-  graph%y2%major_div = 4        
-  graph%y2%label_color=2
-  
+  graph%name           = 'a'
+  graph%x%draw_numbers = F
+  graph%x%draw_label   = F
+  graph_index          = 1
+  graph%box            = 1, 1, 1, 1
+  graph%title          = 'Lattice \gb functions'
+  ! graph%margin =  0.15, 0.06, 0.12, 0.12, '%BOX'
+
+  graph%margin         = 0.15, 0.06, 0.06, 0.12, '%BOX'
+  !----y1
+  graph%y%label        = '\gb\dx\u (m), \gb\dy\u (m)'
+  graph%y%max          = 20
+  graph%y%min          = -20
+  graph%y%major_div    = 4
+  !-----y2
+  graph%y2%label       = 'yafaf'
+  graph%y2%max         = 20
+  graph%y2%min         = -20
+  graph%y2%major_div   = 4
+  graph%y2%label_color = 'red'
+
   !!not needed: graph%n_curve = 2
-  curve(1)%data_source = 'lattice'
-  curve(1)%data_type   = 'beta.a'
+  curve(1)%data_source         = 'lattice'
+  curve(1)%data_type           = 'beta.a'
   curve(1)%y_axis_scale_factor = 1
-  curve(1)%line%color=2
-  curve(1)%line%width=2
-  curve(1)%draw_symbols=.false.
-  curve(2)%data_source = 'lattice'
-  curve(2)%data_type   = 'eta.a'
+  curve(1)%line%color          = 'red'
+  curve(1)%line%width          = 2
+  curve(1)%draw_symbols        = F
+  curve(2)%data_source         = 'lattice'
+  curve(2)%data_type           = 'eta.a'
   curve(2)%y_axis_scale_factor = 1
-  curve(2)%draw_symbols=.false.
-  curve(2)%line%color = 3
-  curve(2)%line%width=2
+  curve(2)%draw_symbols        = F
+  curve(2)%line%color          = 'green'
+  curve(2)%line%width          = 2
 /


### PR DESCRIPTION
## Changes

**Note** tests will continue to fail until upstream bmad fixes its lattices, as we use them in our suite here.

* Reformats `tao.init` and `tao_plot.init` files with `latform`'s new namelist support.
* Fixes unquoted string fields (most common in `universe = n` which seems like it should be an integer)
* Normalizes logicals: `.true.`/`.false.` and currently accepted equivalents become `T`/`F`
* Aligns equals signs and comments in namelist groups
* Uses string constants for colors and other curve enums instead of their integer equivalents for consistency

## Motivation and Context
The recent release of libgfortran 16.0 changed a key aspect of namelist input file evaluation (ref: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=123012). We've just now seen the effects of this due to conda-forge upgrading.

Derived type fields that are of base type `character` (i.e., strings) must have quotes around them, or the namelist parser will cause the process to exit with an error. For example:

```
&tao_d2_data
        d2_data%name = 'L0B'
        universe = 1
        n_d1_data = 1
/
```
Since `universe` is actually a `character(16)`, this is now invalid as of libgfortran 16. It causes `tao` to exit with this error:

```
At line 107 of file /home/conda/feedstock_root/build_artifacts/bmad_1785112804039/work/tao/code/tao_init_data_mod.f90 (unit = 30, file = 'tao.init')
Fortran runtime error: Missing quote while reading item ...
```
