### PR TITLE
REF: templated comparisons in constraints tool

### DIFF
--- a/pytao/constraints/config.py
+++ b/pytao/constraints/config.py
@@ -164,7 +164,7 @@ class IsCloseConstraint(ComparisonConstraint[CompT]):
         comparison_map : dict[str, AnyComparison]
             mapping string -> shared comparisons
         group : str | None
-            _description_
+            Name of group this constraint belongs to, Optional
 
         Returns
         -------
@@ -181,7 +181,7 @@ class IsCloseConstraint(ComparisonConstraint[CompT]):
         reg: list[RegressionResult] = []
         if not isinstance(self.comparison, IsClose):
             raise TypeError(
-                f"Referenced comparison ({self.comparison}) is of"
+                f"Referenced comparison ({self.comparison}) is of "
                 f"incorrect type: {type(self.comparison)}"
             )
 
@@ -225,7 +225,7 @@ class IsLessConstraint(ComparisonConstraint[CompT]):
         crs, reg = super().run(obs_map, saved_obs_map, comparison_map, group)
         if not isinstance(self.comparison, IsLess):
             raise TypeError(
-                f"Referenced comparison ({self.comparison}) is of"
+                f"Referenced comparison ({self.comparison}) is of "
                 f"incorrect type: {type(self.comparison)}"
             )
 
@@ -262,7 +262,7 @@ class RegressionConstraint(Constraint, Generic[CompT]):
             ref_comp = comparison_map[self.comparison]
             if not isinstance(ref_comp, IsClose):
                 raise TypeError(
-                    f"Referenced comparison ({self.comparison}) is of"
+                    f"Referenced comparison ({self.comparison}) is of "
                     f"incorrect type: {type(ref_comp)}"
                 )
             self.comparison = cast(CompT, ref_comp)
@@ -517,7 +517,7 @@ class ConstraintsConfig(ConstraintsBase):
     )
     comparisons: dict[str, AnyComparison] = Field(
         default_factory=dict,
-        description="Mapping from unimque comparison identifier to reusable comparison settings",
+        description="Mapping from unique comparison identifier to reusable comparison settings",
     )
 
     @model_validator(mode="before")

--- a/pytao/constraints/config.py
+++ b/pytao/constraints/config.py
@@ -91,10 +91,14 @@ class ComparisonConstraint(Constraint, Generic[CompT]):
 
     comparison: CompT | str
 
-    @abstractmethod
-    def is_satisfied(
-        self, observations: dict[Observable, Observation]
-    ) -> ComparisonResult: ...
+    # comparison object to be filled by `.run()`
+    _comparison_obj: CompT | None = None
+
+    def is_satisfied(self, observations: dict[Observable, Observation]) -> ComparisonResult:
+        if self._comparison_obj is None:
+            raise RuntimeError(
+                "Comparison has not been run, cannot return a meaningful result"
+            )
 
     def run(
         self,
@@ -107,7 +111,9 @@ class ComparisonConstraint(Constraint, Generic[CompT]):
         if isinstance(self.comparison, str):
             if self.comparison not in common_comparisons_map:
                 raise ValueError(f"Referenced comparison ({self.comparison}) not defined")
-            self.comparison = cast(CompT, common_comparisons_map[self.comparison])
+            self._comparison_obj = cast(CompT, common_comparisons_map[self.comparison])
+        else:
+            self._comparison_obj = self.comparison
 
         missing = [obs for obs in self.required_observables if obs not in obs_map]
         if missing:
@@ -179,10 +185,10 @@ class IsCloseConstraint(ComparisonConstraint[CompT]):
         """
         crs, _ = super().run(obs_map, expected_obs_map, common_comparison_map, group)
         reg: list[RegressionResult] = []
-        if not isinstance(self.comparison, IsClose):
+        if not isinstance(self._comparison_obj, IsClose):
             raise TypeError(
-                f"Referenced comparison ({self.comparison}) is of "
-                f"incorrect type: {type(self.comparison)}"
+                f"Referenced comparison ({self._comparison_obj}) is of "
+                f"incorrect type: {type(self._comparison_obj)}"
             )
 
         if self.regression_check and expected_obs_map is not None:
@@ -190,7 +196,9 @@ class IsCloseConstraint(ComparisonConstraint[CompT]):
                 if obs not in obs_map or obs not in expected_obs_map:
                     reg_result = self.error_result("Missing observation")
                 else:
-                    reg_result = self.comparison.compare(obs_map[obs], expected_obs_map[obs])
+                    reg_result = self._comparison_obj.compare(
+                        obs_map[obs], expected_obs_map[obs]
+                    )
                 reg.append(
                     RegressionResult(
                         group=group,
@@ -223,10 +231,10 @@ class IsLessConstraint(ComparisonConstraint[CompT]):
         group: str | None,
     ) -> tuple[list[ConstraintResult], list[RegressionResult]]:
         crs, reg = super().run(obs_map, expected_obs_map, common_comparison_map, group)
-        if not isinstance(self.comparison, IsLess):
+        if not isinstance(self._comparison_obj, IsLess):
             raise TypeError(
-                f"Referenced comparison ({self.comparison}) is of "
-                f"incorrect type: {type(self.comparison)}"
+                f"Referenced comparison ({self._comparison_obj}) is of "
+                f"incorrect type: {type(self._comparison_obj)}"
             )
 
         return crs, reg
@@ -242,6 +250,9 @@ class RegressionConstraint(Constraint, Generic[CompT]):
     """
 
     comparison: CompT | str
+
+    # comparison object to be filled by `.run()`
+    _comparison_obj: CompT | None = None
 
     @abstractmethod
     def evaluate(self, current: Observation, reference: Observation) -> ComparisonResult: ...
@@ -265,7 +276,9 @@ class RegressionConstraint(Constraint, Generic[CompT]):
                     f"Referenced comparison ({self.comparison}) is of "
                     f"incorrect type: {type(ref_comp)}"
                 )
-            self.comparison = cast(CompT, ref_comp)
+            self._comparison_obj = cast(CompT, ref_comp)
+        else:
+            self._comparison_obj = self.comparison
 
         if obs not in obs_map or obs not in expected_obs_map:
             result = self.error_result("Missing observation")
@@ -314,7 +327,8 @@ class EleIsCloseConstraint(IsCloseConstraint[EleIsClose]):
         return frozenset((self.obs_a, self.obs_b))
 
     def is_satisfied(self, observations: dict[Observable, Observation]) -> EleIsCloseResult:
-        return self.comparison.compare(observations[self.obs_a], observations[self.obs_b])
+        super().is_satisfied(observations=observations)
+        return self._comparison_obj.compare(observations[self.obs_a], observations[self.obs_b])
 
     def error_result(self, error: str) -> EleIsCloseResult:
         return EleIsCloseResult(error=error)
@@ -349,7 +363,8 @@ class EleLessThanConstraint(IsLessConstraint[EleLessThan]):
         return frozenset((self.obs_a, self.obs_b))
 
     def is_satisfied(self, observations: dict[Observable, Observation]) -> EleLessThanResult:
-        return self.comparison.compare(observations[self.obs_a], observations[self.obs_b])
+        super().is_satisfied(observations=observations)
+        return self._comparison_obj.compare(observations[self.obs_a], observations[self.obs_b])
 
     def error_result(self, error: str) -> EleLessThanResult:
         return EleLessThanResult(error=error)
@@ -386,7 +401,8 @@ class DatumIsCloseConstraint(IsCloseConstraint[DatumIsClose]):
         return frozenset((self.obs_a, self.obs_b))
 
     def is_satisfied(self, observations: dict[Observable, Observation]) -> DatumIsCloseResult:
-        return self.comparison.compare(observations[self.obs_a], observations[self.obs_b])
+        super().is_satisfied(observations=observations)
+        return self._comparison_obj.compare(observations[self.obs_a], observations[self.obs_b])
 
     def error_result(self, error: str) -> DatumIsCloseResult:
         return DatumIsCloseResult(error=error)
@@ -421,7 +437,8 @@ class DatumLessThanConstraint(IsLessConstraint[DatumLessThan]):
         return frozenset((self.obs_a, self.obs_b))
 
     def is_satisfied(self, observations: dict[Observable, Observation]) -> DatumLessThanResult:
-        return self.comparison.compare(observations[self.obs_a], observations[self.obs_b])
+        super().is_satisfied(observations=observations)
+        return self._comparison_obj.compare(observations[self.obs_a], observations[self.obs_b])
 
     def error_result(self, error: str) -> DatumLessThanResult:
         return DatumLessThanResult(error=error)
@@ -453,7 +470,7 @@ class EleRegressionConstraint(RegressionConstraint[EleIsClose]):
         return frozenset({self.obs})
 
     def evaluate(self, current: EleObservation, reference: EleObservation) -> EleIsCloseResult:
-        return self.comparison.compare(current, reference)
+        return self._comparison_obj.compare(current, reference)
 
     def error_result(self, error: str) -> EleIsCloseResult:
         return EleIsCloseResult(error=error)
@@ -487,7 +504,7 @@ class DatumRegressionConstraint(RegressionConstraint[DatumIsClose]):
     def evaluate(
         self, current: DatumObservation, reference: DatumObservation
     ) -> DatumIsCloseResult:
-        return self.comparison.compare(current, reference)
+        return self._comparison_obj.compare(current, reference)
 
     def error_result(self, error: str) -> DatumIsCloseResult:
         return DatumIsCloseResult(error=error)

--- a/pytao/constraints/config.py
+++ b/pytao/constraints/config.py
@@ -80,8 +80,8 @@ class Constraint(ConstraintsBase):
     def run(
         self,
         obs_map: dict[Observable, Observation],
-        saved_obs_map: dict[Observable, Observation] | None,
-        comparison_map: dict[str, AnyComparison],
+        expected_obs_map: dict[Observable, Observation] | None,
+        common_comparison_map: dict[str, AnyComparison],
         group: str | None,
     ) -> tuple[list[ConstraintResult], list[RegressionResult]]: ...
 
@@ -99,15 +99,15 @@ class ComparisonConstraint(Constraint, Generic[CompT]):
     def run(
         self,
         obs_map: dict[Observable, Observation],
-        saved_obs_map: dict[Observable, Observation] | None,
-        comparison_map: dict[str, AnyComparison],
+        expected_obs_map: dict[Observable, Observation] | None,
+        common_comparisons_map: dict[str, AnyComparison],
         group: str | None,
     ) -> tuple[list[ConstraintResult], list[RegressionResult]]:
         # replace string comparison reference with real comparison
         if isinstance(self.comparison, str):
-            if self.comparison not in comparison_map:
+            if self.comparison not in common_comparisons_map:
                 raise ValueError(f"Referenced comparison ({self.comparison}) not defined")
-            self.comparison = cast(CompT, comparison_map[self.comparison])
+            self.comparison = cast(CompT, common_comparisons_map[self.comparison])
 
         missing = [obs for obs in self.required_observables if obs not in obs_map]
         if missing:
@@ -148,8 +148,8 @@ class IsCloseConstraint(ComparisonConstraint[CompT]):
     def run(
         self,
         obs_map: dict[Observable, Observation],
-        saved_obs_map: dict[Observable, Observation] | None,
-        comparison_map: dict[str, AnyComparison],
+        expected_obs_map: dict[Observable, Observation] | None,
+        common_comparison_map: dict[str, AnyComparison],
         group: str | None,
     ) -> tuple[list[ConstraintResult], list[RegressionResult]]:
         """
@@ -159,9 +159,9 @@ class IsCloseConstraint(ComparisonConstraint[CompT]):
         ----------
         obs_map : dict[Observable, Observation]
             mapping specified observable -> complete observation
-        saved_obs_map : dict[Observable, Observation] | None
-            mapping observable -> complete observation from saved
-        comparison_map : dict[str, AnyComparison]
+        expected_obs_map : dict[Observable, Observation] | None
+            mapping observable -> complete observation from e.g. lattice
+        common_comparison_map : dict[str, AnyComparison]
             mapping string -> shared comparisons
         group : str | None
             Name of group this constraint belongs to, Optional
@@ -177,7 +177,7 @@ class IsCloseConstraint(ComparisonConstraint[CompT]):
         TypeError
             if comparison references a non-IsClose comparison
         """
-        crs, _ = super().run(obs_map, saved_obs_map, comparison_map, group)
+        crs, _ = super().run(obs_map, expected_obs_map, common_comparison_map, group)
         reg: list[RegressionResult] = []
         if not isinstance(self.comparison, IsClose):
             raise TypeError(
@@ -185,12 +185,12 @@ class IsCloseConstraint(ComparisonConstraint[CompT]):
                 f"incorrect type: {type(self.comparison)}"
             )
 
-        if self.regression_check and saved_obs_map is not None:
+        if self.regression_check and expected_obs_map is not None:
             for obs in self.required_observables:
-                if obs not in obs_map or obs not in saved_obs_map:
+                if obs not in obs_map or obs not in expected_obs_map:
                     reg_result = self.error_result("Missing observation")
                 else:
-                    reg_result = self.comparison.compare(obs_map[obs], saved_obs_map[obs])
+                    reg_result = self.comparison.compare(obs_map[obs], expected_obs_map[obs])
                 reg.append(
                     RegressionResult(
                         group=group,
@@ -218,11 +218,11 @@ class IsLessConstraint(ComparisonConstraint[CompT]):
     def run(
         self,
         obs_map: dict[Observable, Observation],
-        saved_obs_map: dict[Observable, Observation] | None,
-        comparison_map: dict[str, AnyComparison],
+        expected_obs_map: dict[Observable, Observation] | None,
+        common_comparison_map: dict[str, AnyComparison],
         group: str | None,
     ) -> tuple[list[ConstraintResult], list[RegressionResult]]:
-        crs, reg = super().run(obs_map, saved_obs_map, comparison_map, group)
+        crs, reg = super().run(obs_map, expected_obs_map, common_comparison_map, group)
         if not isinstance(self.comparison, IsLess):
             raise TypeError(
                 f"Referenced comparison ({self.comparison}) is of "
@@ -249,17 +249,17 @@ class RegressionConstraint(Constraint, Generic[CompT]):
     def run(
         self,
         obs_map: dict[Observable, Observation],
-        saved_obs_map: dict[Observable, Observation] | None,
-        comparison_map: dict[str, AnyComparison],
+        expected_obs_map: dict[Observable, Observation] | None,
+        common_comparison_map: dict[str, AnyComparison],
         group: str | None,
     ) -> tuple[list[ConstraintResult], list[RegressionResult]]:
-        if saved_obs_map is None:
+        if expected_obs_map is None:
             return [], []
         obs = next(iter(self.required_observables))
         if isinstance(self.comparison, str):
-            if self.comparison not in comparison_map:
+            if self.comparison not in common_comparison_map:
                 raise ValueError(f"Referenced comparison ({self.comparison}) not defined")
-            ref_comp = comparison_map[self.comparison]
+            ref_comp = common_comparison_map[self.comparison]
             if not isinstance(ref_comp, IsClose):
                 raise TypeError(
                     f"Referenced comparison ({self.comparison}) is of "
@@ -267,10 +267,10 @@ class RegressionConstraint(Constraint, Generic[CompT]):
                 )
             self.comparison = cast(CompT, ref_comp)
 
-        if obs not in obs_map or obs not in saved_obs_map:
+        if obs not in obs_map or obs not in expected_obs_map:
             result = self.error_result("Missing observation")
         else:
-            result = self.evaluate(obs_map[obs], saved_obs_map[obs])
+            result = self.evaluate(obs_map[obs], expected_obs_map[obs])
         return [], [
             RegressionResult(
                 group=group,

--- a/pytao/constraints/config.py
+++ b/pytao/constraints/config.py
@@ -1,11 +1,13 @@
 from abc import abstractmethod
-from typing import Annotated, Any, Literal, Union
+from typing import Annotated, Any, Generic, Literal, TypeVar, Union, cast
 
 from pydantic import Field, model_validator
 
 from pytao.constraints.pydantic import ConstraintsBase
 
 from pytao.constraints.observables import (
+    AnyComparison,
+    Comparison,
     ComparisonResult,
     DatumIsClose,
     DatumIsCloseResult,
@@ -32,6 +34,8 @@ from pytao.constraints.observables import (
 )
 from pytao.constraints.results import ConstraintResult, RegressionResult
 from pytao.startup import TaoStartup
+
+CompT = TypeVar("CompT", bound=Comparison[Any])
 
 
 EleObservables = Annotated[
@@ -76,13 +80,16 @@ class Constraint(ConstraintsBase):
     def run(
         self,
         obs_map: dict[Observable, Observation],
-        compare_map: dict[Observable, Observation] | None,
+        saved_obs_map: dict[Observable, Observation] | None,
+        comparison_map: dict[str, AnyComparison],
         group: str | None,
     ) -> tuple[list[ConstraintResult], list[RegressionResult]]: ...
 
 
-class ComparisonConstraint(Constraint):
+class ComparisonConstraint(Constraint, Generic[CompT]):
     """Base for constraints that compare two observations against each other."""
+
+    comparison: CompT | str
 
     @abstractmethod
     def is_satisfied(
@@ -92,9 +99,16 @@ class ComparisonConstraint(Constraint):
     def run(
         self,
         obs_map: dict[Observable, Observation],
-        compare_map: dict[Observable, Observation] | None,
+        saved_obs_map: dict[Observable, Observation] | None,
+        comparison_map: dict[str, AnyComparison],
         group: str | None,
     ) -> tuple[list[ConstraintResult], list[RegressionResult]]:
+        # replace string comparison reference with real comparison
+        if isinstance(self.comparison, str):
+            if self.comparison not in comparison_map:
+                raise ValueError(f"Referenced comparison ({self.comparison}) not defined")
+            self.comparison = cast(CompT, comparison_map[self.comparison])
+
         missing = [obs for obs in self.required_observables if obs not in obs_map]
         if missing:
             missing_labels = ", ".join(obs.label for obs in missing)
@@ -113,7 +127,7 @@ class ComparisonConstraint(Constraint):
         return [cr], []
 
 
-class IsCloseConstraint(ComparisonConstraint):
+class IsCloseConstraint(ComparisonConstraint[CompT]):
     """Base for constraints that use an IsClose comparison operator.
 
     When ``regression_check`` is ``True`` and a comparison baseline is available,
@@ -128,23 +142,55 @@ class IsCloseConstraint(ComparisonConstraint):
         Whether to implicitly define regression checks on the observations from this constraint.
     """
 
-    comparison: IsClose
+    comparison: CompT | str
     regression_check: bool = True
 
     def run(
         self,
         obs_map: dict[Observable, Observation],
-        compare_map: dict[Observable, Observation] | None,
+        saved_obs_map: dict[Observable, Observation] | None,
+        comparison_map: dict[str, AnyComparison],
         group: str | None,
     ) -> tuple[list[ConstraintResult], list[RegressionResult]]:
-        crs, _ = super().run(obs_map, compare_map, group)
+        """
+        Run the constraint, determining if the observables are close
+
+        Parameters
+        ----------
+        obs_map : dict[Observable, Observation]
+            mapping specified observable -> complete observation
+        saved_obs_map : dict[Observable, Observation] | None
+            mapping observable -> complete observation from saved
+        comparison_map : dict[str, AnyComparison]
+            mapping string -> shared comparisons
+        group : str | None
+            _description_
+
+        Returns
+        -------
+        tuple[list[ConstraintResult], list[RegressionResult]]
+
+        Raises
+        ------
+        ValueError
+            if comparison is a reference (string) that is not defined
+        TypeError
+            if comparison references a non-IsClose comparison
+        """
+        crs, _ = super().run(obs_map, saved_obs_map, comparison_map, group)
         reg: list[RegressionResult] = []
-        if self.regression_check and compare_map is not None:
+        if not isinstance(self.comparison, IsClose):
+            raise TypeError(
+                f"Referenced comparison ({self.comparison}) is of"
+                f"incorrect type: {type(self.comparison)}"
+            )
+
+        if self.regression_check and saved_obs_map is not None:
             for obs in self.required_observables:
-                if obs not in obs_map or obs not in compare_map:
+                if obs not in obs_map or obs not in saved_obs_map:
                     reg_result = self.error_result("Missing observation")
                 else:
-                    reg_result = self.comparison.compare(obs_map[obs], compare_map[obs])
+                    reg_result = self.comparison.compare(obs_map[obs], saved_obs_map[obs])
                 reg.append(
                     RegressionResult(
                         group=group,
@@ -158,7 +204,7 @@ class IsCloseConstraint(ComparisonConstraint):
         return crs, reg
 
 
-class IsLessConstraint(ComparisonConstraint):
+class IsLessConstraint(ComparisonConstraint[CompT]):
     """Base for constraints that use an IsLess comparison operator.
 
     Attributes
@@ -167,10 +213,26 @@ class IsLessConstraint(ComparisonConstraint):
         Operator used to evaluate component-wise less-than between two observations.
     """
 
-    comparison: IsLess
+    comparison: CompT | str
+
+    def run(
+        self,
+        obs_map: dict[Observable, Observation],
+        saved_obs_map: dict[Observable, Observation] | None,
+        comparison_map: dict[str, AnyComparison],
+        group: str | None,
+    ) -> tuple[list[ConstraintResult], list[RegressionResult]]:
+        crs, reg = super().run(obs_map, saved_obs_map, comparison_map, group)
+        if not isinstance(self.comparison, IsLess):
+            raise TypeError(
+                f"Referenced comparison ({self.comparison}) is of"
+                f"incorrect type: {type(self.comparison)}"
+            )
+
+        return crs, reg
 
 
-class RegressionConstraint(Constraint):
+class RegressionConstraint(Constraint, Generic[CompT]):
     """Base for constraints that compare current observations against a saved reference.
 
     Attributes
@@ -179,7 +241,7 @@ class RegressionConstraint(Constraint):
         Operator used to compare the current observation against the reference.
     """
 
-    comparison: IsClose
+    comparison: CompT | str
 
     @abstractmethod
     def evaluate(self, current: Observation, reference: Observation) -> ComparisonResult: ...
@@ -187,16 +249,28 @@ class RegressionConstraint(Constraint):
     def run(
         self,
         obs_map: dict[Observable, Observation],
-        compare_map: dict[Observable, Observation] | None,
+        saved_obs_map: dict[Observable, Observation] | None,
+        comparison_map: dict[str, AnyComparison],
         group: str | None,
     ) -> tuple[list[ConstraintResult], list[RegressionResult]]:
-        if compare_map is None:
+        if saved_obs_map is None:
             return [], []
         obs = next(iter(self.required_observables))
-        if obs not in obs_map or obs not in compare_map:
+        if isinstance(self.comparison, str):
+            if self.comparison not in comparison_map:
+                raise ValueError(f"Referenced comparison ({self.comparison}) not defined")
+            ref_comp = comparison_map[self.comparison]
+            if not isinstance(ref_comp, IsClose):
+                raise TypeError(
+                    f"Referenced comparison ({self.comparison}) is of"
+                    f"incorrect type: {type(ref_comp)}"
+                )
+            self.comparison = cast(CompT, ref_comp)
+
+        if obs not in obs_map or obs not in saved_obs_map:
             result = self.error_result("Missing observation")
         else:
-            result = self.evaluate(obs_map[obs], compare_map[obs])
+            result = self.evaluate(obs_map[obs], saved_obs_map[obs])
         return [], [
             RegressionResult(
                 group=group,
@@ -209,7 +283,7 @@ class RegressionConstraint(Constraint):
         ]
 
 
-class EleIsCloseConstraint(IsCloseConstraint):
+class EleIsCloseConstraint(IsCloseConstraint[EleIsClose]):
     """Constraint checking that two element observables are approximately equal.
 
     Attributes
@@ -227,7 +301,7 @@ class EleIsCloseConstraint(IsCloseConstraint):
     constraint_type: Literal["ele_eq"] = "ele_eq"
     obs_a: EleObservables
     obs_b: EleObservables
-    comparison: EleIsClose = EleIsClose()
+    comparison: EleIsClose | str = EleIsClose()
 
     @property
     def label(self) -> str:
@@ -246,7 +320,7 @@ class EleIsCloseConstraint(IsCloseConstraint):
         return EleIsCloseResult(error=error)
 
 
-class EleLessThanConstraint(IsLessConstraint):
+class EleLessThanConstraint(IsLessConstraint[EleLessThan]):
     """Constraint checking that ``obs_a`` is component-wise less than ``obs_b``.
 
     Attributes
@@ -264,7 +338,7 @@ class EleLessThanConstraint(IsLessConstraint):
     constraint_type: Literal["ele_lt"] = "ele_lt"
     obs_a: EleObservables
     obs_b: EleObservables
-    comparison: EleLessThan = EleLessThan()
+    comparison: EleLessThan | str = EleLessThan()
 
     @property
     def label(self) -> str:
@@ -281,7 +355,7 @@ class EleLessThanConstraint(IsLessConstraint):
         return EleLessThanResult(error=error)
 
 
-class DatumIsCloseConstraint(IsCloseConstraint):
+class DatumIsCloseConstraint(IsCloseConstraint[DatumIsClose]):
     """Constraint checking that two datum observables are approximately equal.
 
     Attributes
@@ -299,7 +373,7 @@ class DatumIsCloseConstraint(IsCloseConstraint):
     constraint_type: Literal["datum_eq"] = "datum_eq"
     obs_a: DatumObservables
     obs_b: DatumObservables
-    comparison: DatumIsClose = DatumIsClose()
+    comparison: DatumIsClose | str = DatumIsClose()
 
     @property
     def label(self) -> str:
@@ -318,7 +392,7 @@ class DatumIsCloseConstraint(IsCloseConstraint):
         return DatumIsCloseResult(error=error)
 
 
-class DatumLessThanConstraint(IsLessConstraint):
+class DatumLessThanConstraint(IsLessConstraint[DatumLessThan]):
     """Constraint checking that ``obs_a`` is component-wise less than ``obs_b``.
 
     Attributes
@@ -336,7 +410,7 @@ class DatumLessThanConstraint(IsLessConstraint):
     constraint_type: Literal["datum_lt"] = "datum_lt"
     obs_a: DatumObservables
     obs_b: DatumObservables
-    comparison: DatumLessThan = DatumLessThan()
+    comparison: DatumLessThan | str = DatumLessThan()
 
     @property
     def label(self) -> str:
@@ -353,7 +427,7 @@ class DatumLessThanConstraint(IsLessConstraint):
         return DatumLessThanResult(error=error)
 
 
-class EleRegressionConstraint(RegressionConstraint):
+class EleRegressionConstraint(RegressionConstraint[EleIsClose]):
     """Constraint comparing current element observations against a saved reference.
 
     Attributes
@@ -362,13 +436,13 @@ class EleRegressionConstraint(RegressionConstraint):
         Discriminator literal. Always ``"ele_reg"``.
     obs : EleObservables
         Element observable to evaluate and compare.
-    comparison : EleIsClose
+    comparison : EleIsClose | str
         Comparison operator used to check current against reference.
     """
 
     constraint_type: Literal["ele_reg"] = "ele_reg"
     obs: EleObservables
-    comparison: EleIsClose = EleIsClose()
+    comparison: EleIsClose | str = EleIsClose()
 
     @property
     def label(self) -> str:
@@ -385,7 +459,7 @@ class EleRegressionConstraint(RegressionConstraint):
         return EleIsCloseResult(error=error)
 
 
-class DatumRegressionConstraint(RegressionConstraint):
+class DatumRegressionConstraint(RegressionConstraint[DatumIsClose]):
     """Constraint comparing current datum observations against a saved reference.
 
     Attributes
@@ -400,7 +474,7 @@ class DatumRegressionConstraint(RegressionConstraint):
 
     constraint_type: Literal["datum_reg"] = "datum_reg"
     obs: DatumObservables
-    comparison: DatumIsClose = DatumIsClose()
+    comparison: DatumIsClose | str = DatumIsClose()
 
     @property
     def label(self) -> str:
@@ -440,6 +514,10 @@ class ConstraintsConfig(ConstraintsBase):
     constraints: list[AnyConstraint] | dict[str, list[AnyConstraint]] = Field(
         default_factory=list,
         description="Flat list (ungrouped) or mapping of group name to list of constraints",
+    )
+    comparisons: dict[str, AnyComparison] = Field(
+        default_factory=dict,
+        description="Mapping from unimque comparison identifier to reusable comparison settings",
     )
 
     @model_validator(mode="before")

--- a/pytao/constraints/main.py
+++ b/pytao/constraints/main.py
@@ -39,7 +39,7 @@ def _md_status(passed: bool) -> str:
 def run(
     config: ConstraintsConfig,
     config_dir: Path,
-    compare: SavedObservations | None = None,
+    saved_observations: SavedObservations | None = None,
     verbose: bool = False,
 ) -> tuple[SavedObservations, ConstraintResultsGroup]:
     """
@@ -51,7 +51,7 @@ def run(
         Parsed constraints configuration.
     config_dir : Path
         Directory used to resolve relative paths in the config.
-    compare : SavedObservations, optional
+    saved_observations : SavedObservations, optional
         Previously saved observations for regression comparison.
 
     Returns
@@ -149,13 +149,21 @@ def run(
 
     constraint_results: dict[str | None, list[ConstraintResult]] = {}
     regression_results: dict[str | None, list] = {}
-    compare_map = compare.obs_map if compare is not None else None
+    saved_observation_map = (
+        saved_observations.obs_map if saved_observations is not None else None
+    )
 
     for group, constraints in config.constraints_by_group.items():
         constraint_results[group] = []
         regression_results[group] = []
         for constraint in constraints:
-            crs, reg = constraint.run(obs_map, compare_map, group)
+            # Main entrypoint
+            crs, reg = constraint.run(
+                obs_map=obs_map,
+                saved_obs_map=saved_observation_map,
+                comparison_map=config.comparisons,
+                group=group,
+            )
             constraint_results[group].extend(crs)
             regression_results[group].extend(reg)
 
@@ -460,7 +468,10 @@ def main() -> None:
     save_obs_path = Path(args.save_observations) if args.save_observations else None
 
     saved, results = run(
-        config, config_dir=config_path.parent, compare=compare, verbose=not args.markdown
+        config,
+        config_dir=config_path.parent,
+        saved_observations=compare,
+        verbose=not args.markdown,
     )
 
     if args.markdown:

--- a/pytao/constraints/main.py
+++ b/pytao/constraints/main.py
@@ -160,8 +160,8 @@ def run(
             # Main entrypoint
             crs, reg = constraint.run(
                 obs_map=obs_map,
-                saved_obs_map=saved_observation_map,
-                comparison_map=config.comparisons,
+                expected_obs_map=saved_observation_map,
+                common_comparison_map=config.comparisons,
                 group=group,
             )
             constraint_results[group].extend(crs)

--- a/pytao/constraints/observables/__init__.py
+++ b/pytao/constraints/observables/__init__.py
@@ -59,6 +59,15 @@ AnyObservable = Annotated[
 AnyObservation = Annotated[
     Union[EleObservation, DatumObservation], Field(discriminator="obs_type")
 ]
+AnyComparison = Annotated[
+    Union[
+        EleIsClose,
+        DatumIsClose,
+        EleLessThan,
+        DatumLessThan,
+    ],
+    Field(discriminator="comp_type"),
+]
 AnyComparisonResult = Annotated[
     Union[
         EleIsCloseResult,

--- a/pytao/constraints/observables/datum.py
+++ b/pytao/constraints/observables/datum.py
@@ -102,6 +102,7 @@ class DatumIsClose(IsClose[DatumObservation]):
         Comparison for the design value.
     """
 
+    comp_type: Literal["datum_is_close"] = "datum_is_close"
     model_value_test: TolComparison | None = TolComparison()
     design_value_test: TolComparison | None = None
 
@@ -158,6 +159,7 @@ class DatumLessThan(IsLess[DatumObservation]):
         Check design value.
     """
 
+    comp_type: Literal["datum_is_less"] = "datum_is_less"
     model_value: bool = True
     design_value: bool = False
 

--- a/pytao/constraints/observables/ele.py
+++ b/pytao/constraints/observables/ele.py
@@ -181,6 +181,7 @@ class EleIsClose(IsClose[EleObservation]):
         Comparison for global floor z coordinate.
     """
 
+    comp_type: Literal["ele_is_close"] = "ele_is_close"
     twiss_a: AnyTwissComparison | None = BmagTwissComparison()
     twiss_b: AnyTwissComparison | None = BmagTwissComparison()
 
@@ -395,6 +396,8 @@ class EleLessThan(IsLess[EleObservation]):
     floor_z : bool
         Check global floor z coordinate.
     """
+
+    comp_type: Literal["ele_is_less"] = "ele_is_less"
 
     beta_a: bool = False
     alpha_a: bool = False

--- a/pytao/tests/constraints/data/constraints_grouped_comps_consolidated.yaml
+++ b/pytao/tests/constraints/data/constraints_grouped_comps_consolidated.yaml
@@ -1,0 +1,88 @@
+# Lattice definitions in the form of a dict: lattice_id -> TaoStartup (ie the arguments to Tao(...))
+lattices:
+  lat_a:
+    lattice_file: lattices/lat_a.lat.bmad
+  lat_b:
+    lattice_file: lattices/lat_b.lat.bmad
+  lat_c:
+    lattice_file: lattices/lat_c.lat.bmad
+
+comparisons:
+  default_comp:
+    comp_type: ele_is_less
+    beta_a: true
+    beta_b: true
+
+# Grouped constraints: a dict of group_name -> list[Constraint]. Each constraint defined by its `constraint_type`. The
+# constraints each have two observables, the type of which is set by `obs_type` and can be derived from the lattice
+# or a literal. The constraints may include short descriptions and longer comments for documentation.
+constraints:
+  Lattice-Consistency:
+    - constraint_type: ele_eq
+      description: Short description, lat_a, lat_b treaty point
+      comment: Longer comment included on error and in reports. eg Please rerun `tune_matcher.tao` in event of failure.
+      obs_a:
+        obs_type: ele
+        lattice_id: lat_a
+        ele_id: END
+      obs_b:
+        obs_type: ele
+        lattice_id: lat_b
+        ele_id: BEGINNING
+
+    - constraint_type: ele_eq
+      description: Trivial test
+      obs_a:
+        obs_type: ele
+        lattice_id: lat_a
+        ele_id: END
+      obs_b:
+        obs_type: ele
+        lattice_id: lat_a
+        ele_id: END
+
+  Sanity-Checks:
+    - constraint_type: ele_lt
+      description: lat_a beta sanity check
+      obs_a:
+        obs_type: ele_max
+        lattice_id: lat_a
+      obs_b:
+        obs_type: ele_literal
+        beta_a: 200
+        beta_b: 200
+      comparison: default_comp
+
+    - constraint_type: ele_lt
+      description: lat_b beta sanity check
+      obs_a:
+        obs_type: ele_max
+        lattice_id: lat_b
+      obs_b:
+        obs_type: ele_literal
+        beta_a: 200
+        beta_b: 200
+      comparison: default_comp
+  
+    - constraint_type: ele_lt
+      description: lat_c beta sanity check
+      comment: This constraint is expected to fail
+      obs_a:
+        obs_type: ele_max
+        lattice_id: lat_c
+      obs_b:
+        obs_type: ele_literal
+        beta_a: 0
+        beta_b: 200
+      comparison: default_comp
+  
+  # Define some regression tests. Note: we split them out in their own group here, but they are constraints in their own
+  # right and may be placed anywhere in the file. IsCloseConstraint's also implicitly define regression checks. 
+  Regression:
+    - constraint_type: ele_reg
+      description: Middle of lat_a
+      comment: lat_a should not be changing, check middle Twiss
+      obs:
+        obs_type: ele
+        lattice_id: lat_a
+        ele_id: MAR_MID

--- a/pytao/tests/constraints/test_cli.py
+++ b/pytao/tests/constraints/test_cli.py
@@ -8,7 +8,11 @@ from pytao.constraints.main import main
 from pytao.constraints.results import ConstraintResultsGroup, SavedObservations
 
 DATA_DIR = pathlib.Path(__file__).parent / "data"
-CONFIGS = ["constraints.yaml", "constraints_grouped.yaml"]
+CONFIGS = [
+    "constraints.yaml",
+    "constraints_grouped.yaml",
+    "constraints_grouped_comps_consolidated.yaml",
+]
 REFERENCE_PATH = DATA_DIR / "reference_results.json"
 
 

--- a/pytao/tests/constraints/test_run.py
+++ b/pytao/tests/constraints/test_run.py
@@ -194,7 +194,7 @@ def test_run_regression_missing_observation():
         constraints=[DatumRegressionConstraint(obs=obs)],
     )
     compare = SavedObservations(entries=[])
-    _, results = run(config, DATA_DIR, compare=compare)
+    _, results = run(config, DATA_DIR, saved_observations=compare)
     reg = list(results.iter_regression())
     assert len(reg) == 1
     _, rr = reg[0]
@@ -223,7 +223,7 @@ def test_run_regression_multiple_groups():
             ),
         ]
     )
-    _, results = run(config, DATA_DIR, compare=compare)
+    _, results = run(config, DATA_DIR, saved_observations=compare)
     assert sum(len(v) for v in results.regression.values()) == 2
     by_group = {rr.group: rr for _, rr in results.iter_regression()}
     a = by_group["A"]


### PR DESCRIPTION
## Description
- adds ability to refer to comparisons by name (string).  These names refer to a top-level list of comparisons which can be reused across the entire configuration.

## Context
The current schema resulted in lots of comparison duplication, and we'd like to DRY this out a bit. 