### PR TITLE
FIX: scientific notation with both + and - in it

### DIFF
--- a/pytao/tests/test_parsers.py
+++ b/pytao/tests/test_parsers.py
@@ -4,7 +4,12 @@ import numpy as np
 import pytest
 
 from .. import AnyTao
-from ..util.parsers import parse_derivative, parse_show_version, parse_tao_python_data
+from ..util.parsers import (
+    parse_derivative,
+    parse_show_version,
+    parse_tao_python_data,
+    _value_float_or_none as value_float_or_none,
+)
 from .conftest import ensure_successful_parsing
 from .test_interface_commands import new_tao
 
@@ -765,3 +770,18 @@ def test_parse_derivative_mixed_universes_and_chunking():
     assert result[2].shape == (2, 3)
     expected_u2 = np.array([[21.0, 22.0, 23.0], [24.0, 25.0, 26.0]])
     np.testing.assert_array_equal(result[2], expected_u2)
+
+
+@pytest.mark.parametrize(
+    ["value", "expected"],
+    [
+        pytest.param("", None),
+        pytest.param("1", 1.0),
+        pytest.param("1-5", 1e-5),
+        pytest.param("1+5", 1e5),
+        pytest.param("-1-5", -1e-5),
+        pytest.param("+1-5", 1e-5),
+    ],
+)
+def test_fix_sci_notation(value: str, expected):
+    assert value_float_or_none(value) == expected

--- a/pytao/util/parsers.py
+++ b/pytao/util/parsers.py
@@ -641,13 +641,7 @@ def fix_value(value: str, typ: type):
     if typ is FloatOrNone:
         return _value_float_or_none(value)
     if typ is float:
-        if ("-" in value or "+" in value) and "e" not in value:
-            # TODO: some floating point values like gg%deriv of ele_gen_grad_map
-            # are formatted incorrectly
-            try:
-                return float(value)
-            except ValueError:
-                return float(value.replace("-", "e-").replace("+", "e+"))
+        return _fix_float_scientific_notation(value)
 
     return typ(value)
 
@@ -1365,9 +1359,26 @@ def parse_lat_param_units(lines, cmd="") -> str:
     return lines[0]
 
 
+def _fix_float_scientific_notation(value: str) -> float:
+    if ("-" in value or "+" in value) and "e" not in value:
+        # TODO: some floating point values like gg%deriv of ele_gen_grad_map
+        # are formatted incorrectly:
+        #   e.g., 1.42+245 -> 1.42e245
+        try:
+            return float(value)
+        except ValueError:
+            if value.startswith(("-", "+")):
+                sign, value = value[0], value[1:]
+            else:
+                sign = ""
+
+            return float(sign + value.replace("-", "e-").replace("+", "e+"))
+    return float(value)
+
+
 def _value_float_or_none(s: str):
     s = s.strip()
-    return None if s == "" else float(s)
+    return None if s == "" else _fix_float_scientific_notation(s)
 
 
 def parse_lord_control(lines, cmd="") -> list[LordControlInfo]:


### PR DESCRIPTION
Mistaken fixing of Fortran-style scientific notation variant without `e` in it;
we somehow never hit a negative number that needed fixing before.

We should fix this upstream in Bmad sooner rather than later. An LLM should make finding and fixing the incorrect representations easier.