### PR TITLE
ENH: no_digested option for lattice file export

### DIFF
--- a/pytao/model/config.py
+++ b/pytao/model/config.py
@@ -30,6 +30,22 @@ logger = logging.getLogger(__name__)
 setattr(_tao_pystructs_logger, "logger", logger)
 
 
+def _prepend_no_digested(fn: pathlib.Path) -> bool:
+    """
+    Prepend `no_digested` marker in the lattice file.
+
+    Returns
+    -------
+    `True` if the file was rewritten.
+    """
+    contents = fn.read_text()
+    if "no_digested" in contents:
+        return False
+
+    fn.write_text(f"no_digested\n{contents}")
+    return True
+
+
 class TaoConfig(TaoSettableModel):
     """
     Tao Configuration model which defines how to start Tao and configure it.
@@ -74,6 +90,7 @@ class TaoConfig(TaoSettableModel):
         lat_name: str | None = None,
         shebang: str = "/usr/bin/env bash",
         tao_binary: str = "tao",
+        no_digested: bool = True,
     ) -> tuple[pathlib.Path, pathlib.Path]:
         """
         Write a loader script to launch Tao with these startup parameters.
@@ -93,6 +110,10 @@ class TaoConfig(TaoSettableModel):
         lat_name : str or None, optional
             The lattice filename to write, if `tao` is specified.
             Defaults to ``"{prefix}.lat.bmad"``.
+        no_digested : bool, optional
+            If True, sets `no_digested` in the written lattice file.
+            Only applies when `tao` instance is provided.
+            By default True.
 
         Returns
         -------
@@ -131,6 +152,9 @@ class TaoConfig(TaoSettableModel):
             if mkdir:
                 full_lat_path.parent.mkdir(exist_ok=True, parents=True)
             tao.cmd(f"write bmad '{full_lat_path}'")
+
+            if no_digested:
+                _prepend_no_digested(full_lat_path)
 
         lines = [
             f"#!{shebang}",

--- a/pytao/tests/ele/test_model_classes.py
+++ b/pytao/tests/ele/test_model_classes.py
@@ -69,6 +69,7 @@ def test_tao_config_shell_script(
 
     if with_tao:
         assert (tmp_path / "foo.lat.bmad").exists()
+        assert "no_digested" in (tmp_path / "foo.lat.bmad").read_text()
     else:
         assert not (tmp_path / "foo.lat.bmad").exists()
 


### PR DESCRIPTION
Closes #197 

Per the bmad docs:

> The no_digested statement if present, will prevent Bmad from creating a digested file (§3.2). That is,
> the lattice file will always be parsed when a program is run. The write_digested statement will cancel
> a no_digested statement.