### PR TITLE
FIX: Lattice.from_tao_unique with tracking ele range

### DIFF
--- a/pytao/model/ele/ele.py
+++ b/pytao/model/ele/ele.py
@@ -2361,6 +2361,9 @@ class Lattice(TaoBaseModel):
         """
         Create a `Lattice` object from unique elements of the lattice.
 
+        When `track_start` or `track_end` are specified, unique elements
+        associated with elements in that range are returned.
+
         Parameters
         ----------
         tao : Tao
@@ -2384,20 +2387,32 @@ class Lattice(TaoBaseModel):
         -------
         Lattice
         """
-        indices: list[int] = [
-            int(idx)
-            for idx in cast(
-                list,
-                tao.lat_list(
-                    "*", "ele.ix_ele", flags="-no_slaves", ix_branch=ix_branch, ix_uni=ix_uni
-                ),
+
+        if track_start is not None or track_end is not None:
+            indices = _used_unique_element_indices(
+                tao,
+                track_start=track_start,
+                track_end=track_end,
+                ix_uni=ix_uni,
+                ix_branch=ix_branch,
             )
-        ]
-        ix_start = get_element_index(tao, track_start) if track_start else 0
-        ix_end = get_element_index(tao, track_end) if track_end else max(indices)
+        else:
+            indices = [
+                int(idx)
+                for idx in list(
+                    tao.lat_list(
+                        "*",
+                        "ele.ix_ele",
+                        flags="-no_slaves",
+                        ix_branch=ix_branch,
+                        ix_uni=ix_uni,
+                    ),
+                )
+            ]
+
         return cls.from_tao_eles(
             tao=tao,
-            eles=[ix_ele for ix_ele in indices if ix_start <= ix_ele <= ix_end],
+            eles=list(indices),
             which=which,
             **kwargs,
         )
@@ -2454,8 +2469,8 @@ class Lattice(TaoBaseModel):
                 ),
             )
         ]
-        ix_start = get_element_index(tao, track_start) if track_start else 0
-        ix_end = get_element_index(tao, track_end) if track_end else max(indices)
+        ix_start = get_element_index(tao, track_start) if track_start is not None else 0
+        ix_end = get_element_index(tao, track_end) if track_end is not None else max(indices)
         return cls.from_tao_eles(
             tao=tao,
             eles=[ix_ele for ix_ele in indices if ix_start <= ix_ele <= ix_end],
@@ -2527,3 +2542,95 @@ def restore_raw_element_ndarrays(ele: dict) -> None:
             value = comb.get(key)
             if value is not None:
                 comb[key] = _PydanticNDArray._pydantic_validate(value, None)
+
+
+def _id_to_branch_and_index(location: str) -> tuple[str, int]:
+    """
+    Split an element ID like ``"1@0>>874"`` into branch and index.
+    """
+
+    prefix, _, ix = location.rpartition(">>")
+    return prefix.split("@")[-1], int(ix)
+
+
+def _direct_lord_ids(tao: Tao, ele_id: str, branch: str, ix_ele: int) -> set[str]:
+    """
+    Get the IDs (e.g., ``"0>>874"``) of the direct lords of an element.
+    """
+    lords: set[str] = set()
+    in_block = False
+    for row in tao.ele_lord_slave(ele_id):
+        location = row.get("location_name", "")
+        if row["type"] == "Element":
+            in_block = _id_to_branch_and_index(location) == (branch, ix_ele)
+        elif row["type"] == "Lord" and in_block:
+            lords.add(location)
+    return lords
+
+
+def _used_unique_element_indices(
+    tao: Tao,
+    *,
+    track_start: ElementID | str | int | None = None,
+    track_end: ElementID | str | int | None = None,
+    ix_uni: str = "",
+    ix_branch: str = "",
+) -> list[int]:
+    """
+    Find the unique (no-slave) elements used within a tracked range.
+
+    The result contains the in-range tracked elements which are not slaves,
+    plus all lords (super, multipass, overlay, group, girder, ...) reachable
+    from any in-range tracked element.
+
+    Parameters
+    ----------
+    tao : Tao
+        Tao instance.
+    track_start : str or int, optional
+        First tracked element (inclusive).  Defaults to the start of the
+        branch.  This does not need to be a unique element itself.
+    track_end : str or int, optional
+        Last tracked element (inclusive).  Defaults to the end of the branch.
+    ix_uni : str, optional
+        Universe index, by default "".
+    ix_branch : str, optional
+        Branch index, by default "".
+
+    Returns
+    -------
+    list of int
+    """
+
+    def lat_list(who: str, flags: str) -> list:
+        return list(tao.lat_list("*", who, flags=flags, ix_uni=ix_uni, ix_branch=ix_branch))
+
+    unique_indices = {int(ix) for ix in lat_list("ele.ix_ele", "-no_slaves")}
+    track_indices = [int(ix) for ix in lat_list("ele.ix_ele", "-track_only")]
+    track_num_lords = [int(num) for num in lat_list("ele.n_lord", "-track_only")]
+
+    ix_start = get_element_index(tao, track_start) if track_start is not None else 0
+    ix_end = get_element_index(tao, track_end) if track_end is not None else max(track_indices)
+
+    uni_prefix = f"{ix_uni}@" if ix_uni else ""
+    branch = ix_branch or "0"
+
+    used: set[int] = set()
+    pending: set[str] = set()
+    for ix, num_lords in zip(track_indices, track_num_lords):
+        if ix_start <= ix <= ix_end:
+            used.add(ix)
+            if num_lords:
+                pending.add(f"{branch}>>{ix}")
+
+    seen_locations = set(pending)
+    while pending:
+        lords: set[str] = set()
+        for location in pending:
+            lord_branch, ix = _id_to_branch_and_index(location)
+            lords |= _direct_lord_ids(tao, f"{uni_prefix}{location}", lord_branch, ix)
+        pending = lords - seen_locations
+        seen_locations |= lords
+        used |= {_id_to_branch_and_index(location)[1] for location in lords}
+
+    return sorted(used & unique_indices)

--- a/pytao/tests/ele/test_ele.py
+++ b/pytao/tests/ele/test_ele.py
@@ -11,7 +11,11 @@ import pytao
 from pytao import SubprocessTao
 from pytao.model.base import TaoBaseModel, format_from_filename
 from pytao.model.ele import Element, Lattice
-from pytao.model.ele.ele import restore_raw_element_ndarrays
+from pytao.model.ele.ele import (
+    _used_unique_element_indices,
+    get_element_index,
+    restore_raw_element_ndarrays,
+)
 from pytao.model.ele.time_stats import _PytaoStatistics, get_pytao_statistics
 from pytao.model.types import NDArray, empty_ndarray
 
@@ -322,6 +326,102 @@ def test_lattice_track_start(cbeta_ffag_tao: SubprocessTao, pytao_stats: _PytaoS
     assert len(removed_indices)
     for idx in removed_indices:
         assert idx not in until_20.by_element_index
+
+
+@pytest.fixture(scope="module")
+def erl_tao():
+    with SubprocessTao(
+        init_file="$ACC_ROOT_DIR/bmad-doc/tao_examples/erl/tao.init",
+        noplot=True,
+    ) as tao:
+        yield tao
+
+
+def _element_names_by_index(tao: SubprocessTao) -> dict[int, str]:
+    return {
+        int(ix): name
+        for ix, name in zip(
+            tao.lat_list("*", "ele.ix_ele", flags=""),
+            tao.lat_list("*", "ele.name", flags=""),
+        )
+    }
+
+
+def _used_unique_names(
+    tao: SubprocessTao,
+    track_start: str | int,
+    track_end: str | int,
+) -> set[str]:
+    names = _element_names_by_index(tao)
+    indices = _used_unique_element_indices(tao, track_start=track_start, track_end=track_end)
+    return {names[ix] for ix in indices}
+
+
+@pytest.mark.parametrize("tao_fixture", ["erl_tao", "cbeta_ffag_tao"])
+def test_used_unique_full_range_matches_no_slaves(
+    request: pytest.FixtureRequest, tao_fixture: str
+):
+    tao: SubprocessTao = request.getfixturevalue(tao_fixture)
+    last_tracked = max(int(ix) for ix in tao.lat_list("*", "ele.ix_ele", flags="-track_only"))
+    no_slaves = sorted(int(ix) for ix in tao.lat_list("*", "ele.ix_ele", flags="-no_slaves"))
+    assert (
+        _used_unique_element_indices(tao, track_start=0, track_end=last_tracked) == no_slaves
+    )
+
+
+@pytest.mark.parametrize(
+    ("element", "expected"),
+    [
+        # Multipass slave -> its multipass lord, plus the overlay controlling
+        # the lord.  Unrelated elements sharing the overlay (e.g. CAV2 for a
+        # CAV1 range) must not be pulled in.
+        pytest.param("CAV1\\1", {"CAV1", "O_PHASE"}, id="multipass-pass-1"),
+        pytest.param("CAV2\\2", {"CAV2", "O_PHASE"}, id="multipass-pass-2"),
+        pytest.param("T1", {"T1"}, id="free-element"),
+        pytest.param(0, {"BEGINNING"}, id="track-end-zero"),
+    ],
+)
+def test_used_unique_multipass(erl_tao: SubprocessTao, element: str | int, expected: set[str]):
+    assert _used_unique_names(erl_tao, element, element) == expected
+
+
+def test_used_unique_multipass_range(erl_tao: SubprocessTao):
+    # Tracking through all of pass 1 uses every multipass lord and the
+    # overlay, but not the elements beyond the range (T1, END).
+    ix_end = get_element_index(erl_tao, "LINAC.END\\1")
+    assert _used_unique_names(erl_tao, 0, ix_end) == {
+        "BEGINNING",
+        "LINAC.BEG",
+        "D1",
+        "CAV1",
+        "D2",
+        "CAV2",
+        "D3",
+        "LINAC.END",
+        "O_PHASE",
+    }
+
+
+@pytest.mark.parametrize(
+    ("element", "expected"),
+    [
+        pytest.param("FA.QUA01#1", {"FA.QUA01"}, id="super-slave"),
+        # A super slave with two overlapping superimposed lords
+        pytest.param("FA.PIP02\\FA.COR01", {"FA.PIP02", "FA.COR01"}, id="overlapping-lords"),
+    ],
+)
+def test_used_unique_superimposed(
+    cbeta_ffag_tao: SubprocessTao, element: str, expected: set[str]
+):
+    ix = get_element_index(cbeta_ffag_tao, element)
+    assert _used_unique_names(cbeta_ffag_tao, ix, ix) == expected
+
+
+def test_from_tao_unique_range_multipass(erl_tao: SubprocessTao):
+    lat = Lattice.from_tao_unique(
+        erl_tao, defaults=True, track_start="CAV1\\1", track_end="CAV1\\1"
+    )
+    assert {ele.name for ele in lat.elements} == {"CAV1", "O_PHASE"}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Changes

Properly (well, hopefully) detect all unique elements based on a given tracking range in `Lattice.from_tao_unique`.

### Background

Prior to this PR, if you passed a range that was part of the tracking elements, you wouldn't get the elements that you expect.
This is of course due to how Tao lays out these elements. When viewed as just the array of `1..max_eles` it's like so:
```
[ tracking eles ] | [ lord eles ]
```
In order to then get the unique element names from that set of tracking elements, you have to do some recursive dereferencing of the lords from the slave elements and combine those all together.